### PR TITLE
chore: bump docker images to latest versions

### DIFF
--- a/ansible/tasks/apps.yml
+++ b/ansible/tasks/apps.yml
@@ -337,7 +337,7 @@
 - name: ESPHome container
   community.docker.docker_container:
     name: esphome
-    image: ghcr.io/esphome/esphome:2025.11.5@sha256:a22312011695efb5c37680682654c1b5cd2dcec4804ba5f3d4af5dd9093e592f
+    image: ghcr.io/esphome/esphome:2026.4.2@sha256:a2784bc539dcf7529241bfe4425d645f1076031f9bf9ce07f5d59d1c45e9ff22
     comparisons:
       image: strict
       labels: allow_more_present
@@ -409,7 +409,7 @@
 # - name: Home Assistant container
 #   community.docker.docker_container:
 #     name: home-assistant
-#     image: ghcr.io/home-assistant/home-assistant:2025.10.2@sha256:5ae78cf2e6d8b53439cac50ed184ff1336cfbbb878fce16f75589e048fcdcdd9
+#     image: ghcr.io/home-assistant/home-assistant:2026.4.4@sha256:c1e5f0147f4cb51ccb05bb30b62a1269cc1bd48a6274792d3b38a77ab274dfd2
 #     comparisons:
 #       image: strict
 #       labels: allow_more_present
@@ -466,7 +466,7 @@
 # - name: Homepage container
 #   community.docker.docker_container:
 #     name: homepage
-#     image: ghcr.io/gethomepage/homepage:v1.5.0@sha256:e7fc26f914cf5e7dcd6c566e24ca218addb879aa76478ad4a553b1f9ae48b1d7
+#     image: ghcr.io/gethomepage/homepage:v1.12.3@sha256:cc84f2f5eb3c7734353701ccbaa24ed02dacb0d119114e50e4251e2005f3990a
 #     comparisons:
 #       image: strict
 #       labels: allow_more_present


### PR DESCRIPTION
## Summary

Bumps Docker images in \`ansible/tasks/apps.yml\` to the latest upstream releases with fresh \`@sha256:\` digests.

| Image | Old | New | Status |
|---|---|---|---|
| \`ghcr.io/esphome/esphome\` | \`2025.11.5\` | **\`2026.4.2\`** | active |
| \`ghcr.io/home-assistant/home-assistant\` | \`2025.10.2\` | **\`2026.4.4\`** | commented out |
| \`ghcr.io/gethomepage/homepage\` | \`v1.5.0\` | **\`v1.12.3\`** | commented out |

All other dependencies (Ansible collections in \`requirements.yml\`, the \`geerlingguy.firewall\` role, every GitHub Action, and the \`alloy_grafana_version\`/\`grafana_version\`/\`prometheus_version\` vars in \`group_vars/all.yml\`) are already at their latest versions and have proper Renovate tracking — no \`# renovate:\` comments needed elsewhere.

## ESPHome major version impact (2025.11.5 → 2026.4.2)

This is the only **major** jump (~5 months of releases). Reviewed every breaking change against the actively used config (Apollo MSR-2, ESP32-C3, esp-idf framework).

### Compatibility analysis for Apollo MSR-2

\`MSR-2/Core.yaml\` uses: \`esp32\` (esp32c3/esp-idf), \`captive_portal\`, \`web_server v3\`, \`i2c\`, \`uart\`, \`ld2410\`, \`scd4x\`, \`ltr390\`, \`dps310\`, \`internal_temperature\`, \`wifi_signal\`, \`uptime\`, \`wifi_info\`, \`esp32_rmt_led_strip\`, \`rtttl\`, \`ledc\`, \`factory_reset\`. \`min_version: 2025.2.0\` — satisfied.

| 2026.x breaking change | Affects MSR-2? |
|---|---|
| ESP32 default 240 MHz | No — ESP32-C3 USB-powered, no battery concern |
| ESP32 partition table change | One slow OTA on first upgrade; NVS preserved by name |
| LVGL v9 upgrade | Not used |
| I2S legacy driver removed | Not used |
| Arduino libs disabled by default | Uses esp-idf, not Arduino |
| ESP32 cert bundle reduced | No HTTPS calls |
| Cover \`on_open\` → \`on_opened\` | No covers |
| Sensor/TextSensor \`.raw_state\` removed | No lambdas use \`.raw_state\` |
| Substitution dict precedence change | No conflicting substitutions |
| Prometheus \`light_color_*\` conditional | Has RGB light; metrics still emitted |

**Verdict:** MSR-2 fully compatible with 2026.4.2. Expect one slower OTA cycle for the partition-table migration, then normal operation.

## Verification

- Lint passes on edited file (3 pre-existing failures at lines 554/559 in unrelated PipeWire tasks, not introduced here)
- Image digests fetched live from \`ghcr.io\` registry
- All \`# keep-sorted\` blocks remain valid