### PR TITLE
fix: add missing image file argument to boot partition mount command

### DIFF
--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -96,7 +96,7 @@ jobs:
           touch ssh_marker && mcopy -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" ssh_marker ::ssh && rm ssh_marker
 
           # Create userconf.txt for pi user with password 'raspberry'
-          ENCRYPTED_PASS=$(python3 -c "import crypt; print(crypt.crypt('raspberry', crypt.mksalt(crypt.METHOD_SHA256)))")
+          ENCRYPTED_PASS=$(openssl passwd -5 raspberry)
           echo "pi:${ENCRYPTED_PASS}" > userconf.txt
           mcopy -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" userconf.txt ::userconf.txt && rm userconf.txt
 

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -144,7 +144,9 @@ jobs:
         run: |
           # Create Raspberry Pi-specific files with expected content to prevent unnecessary reboot
           # The playbook uses blockinfile for config.txt and lineinfile for cmdline.txt
-          sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@127.0.0.1 bash -s <<'REMOTE_SCRIPT'
+          sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@127.0.0.1 bash -euxo pipefail -s <<'REMOTE_SCRIPT'
+          # Wait for cloud-init to finish (it holds apt lock)
+          sudo cloud-init status --wait
           sudo mkdir -p /boot/firmware
           # Install packages that the playbook expects (present on RPi OS but not Debian cloud)
           sudo apt-get update -qq && sudo apt-get install -y -qq cron gnupg logrotate rsync

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   ansible-raspberry-pi-os-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     defaults:
       run:
         shell: bash -euxo pipefail {0}

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -152,6 +152,10 @@ jobs:
           echo 'console=tty1 root=/dev/vda1 cgroup_enable=cpuset cgroup_enable=memory psi=1' | sudo tee /boot/firmware/cmdline.txt
           # Create sshd service alias (Debian uses 'ssh', RPi OS uses 'sshd')
           sudo ln -sf /lib/systemd/system/ssh.service /etc/systemd/system/sshd.service
+          # Create dummy systemd units for RPi OS-specific services that the playbook disables
+          for SVC in cloud-init-main cloud-init-network console-setup keyboard-setup regenerate_ssh_host_keys sshd-keygen sshswitch; do
+            printf '[Unit]\nDescription=Dummy %s\n[Service]\nType=oneshot\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' "${SVC}" | sudo tee "/etc/systemd/system/${SVC}.service"
+          done
           sudo systemctl daemon-reload
           REMOTE_SCRIPT
 

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -153,10 +153,6 @@ jobs:
           # Pre-install GPG keys for Docker and Mosquitto repos
           # Docker key is armored and needs dearmoring for deb822 signed_by
           curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
-          # Mosquitto key is binary but the playbook saves it with .asc extension
-          # Convert to armored format matching the .asc extension
-          # get_url won't overwrite since the file already exists
-          curl -fsSL https://repo.mosquitto.org/debian/mosquitto-repo.gpg | sudo gpg --enarmor | sudo sed 's/ARMORED FILE/PUBLIC KEY BLOCK/' | sudo tee /etc/apt/trusted.gpg.d/mosquitto-repo.asc > /dev/null
           # Create restore logs to skip backup restore tasks (backup server is unreachable in CI)
           sudo touch /var/log/restore-prometheus.log /var/log/restore-hass.log
           # Pre-populate config.txt with the content the playbook would write (blockinfile)

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -109,9 +109,16 @@ jobs:
           cp /usr/share/AAVMF/AAVMF_CODE.fd flash0.img
           cp /usr/share/AAVMF/AAVMF_VARS.fd flash1.img
 
-          # Start QEMU in background with KVM (native arm64 runner)
+          # Start QEMU in background (use KVM if available, otherwise TCG)
+          if [ -e /dev/kvm ]; then
+            ACCEL_OPTS="-accel kvm -cpu host"
+          else
+            ACCEL_OPTS="-accel tcg -cpu cortex-a72"
+          fi
+
+          # shellcheck disable=SC2086
           qemu-system-aarch64 \
-            -machine virt,gic-version=max -accel kvm -cpu host -m 2048 -smp 2 \
+            -machine virt,gic-version=max ${ACCEL_OPTS} -m 2048 -smp 2 \
             -drive if=pflash,format=raw,file=flash0.img,readonly=on \
             -drive if=pflash,format=raw,file=flash1.img \
             -drive if=virtio,file=raspios.qcow2,format=qcow2 \

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -62,8 +62,8 @@ jobs:
           IMAGE_FILE="raspios.img"
 
           # Generate SSH keypair for authentication
-          ssh-keygen -t ed25519 -f "${HOME}/.ssh/qemu_key" -N "" -q
-          SSH_PUBKEY=$(cat "${HOME}/.ssh/qemu_key.pub")
+          ssh-keygen -t ed25519 -f "${HOME}/.ssh/id_ed25519" -N "" -q
+          SSH_PUBKEY=$(cat "${HOME}/.ssh/id_ed25519.pub")
 
           # Resize image to give more space for packages
           qemu-img resize -f raw "${IMAGE_FILE}" 8G
@@ -153,7 +153,7 @@ jobs:
           QEMU_PID=$!
           echo "QEMU_PID=${QEMU_PID}" >> "${GITHUB_ENV}"
 
-          SSH_OPTS="-i ${HOME}/.ssh/qemu_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
 
           # Wait for SSH to become available (timeout 5 minutes)
           echo "Waiting for SSH to become available..."
@@ -188,7 +188,6 @@ jobs:
 
           [raspberry_pi:vars]
           ansible_user=pi
-          ansible_ssh_private_key_file=~/.ssh/qemu_key
           ansible_port=2222
           ansible_python_interpreter=/usr/bin/python3
           ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -148,10 +148,10 @@ jobs:
           sudo mkdir -p /boot/firmware
           # Install packages that the playbook expects (present on RPi OS but not Debian cloud)
           sudo apt-get update -qq && sudo apt-get install -y -qq cron gnupg logrotate rsync
-          # Install Docker GPG key and repo (the playbook's get_url downloads armored key which needs dearmoring)
+          # Pre-install dearmored GPG keys for Docker and Mosquitto repos
+          # The playbook downloads armored keys via get_url but deb822 signed_by needs dearmored keys
           curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
-          echo "deb [signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" | sudo tee /etc/apt/sources.list.d/docker.list
-          sudo apt-get update -qq && sudo apt-get install -y -qq docker-ce docker-ce-cli containerd.io
+          curl -fsSL https://repo.mosquitto.org/debian/mosquitto-repo.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/mosquitto-repo.asc
           # Create restore logs to skip backup restore tasks (backup server is unreachable in CI)
           sudo touch /var/log/restore-prometheus.log /var/log/restore-hass.log
           # Pre-populate config.txt with the content the playbook would write (blockinfile)

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           printf '%s\n' \
             "[raspberry_pi]" \
-            "localhost" \
+            "rpi-test ansible_host=127.0.0.1" \
             "" \
             "[raspberry_pi:vars]" \
             "ansible_user=pi" \

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -147,7 +147,9 @@ jobs:
           sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@127.0.0.1 bash -s <<'REMOTE_SCRIPT'
           sudo mkdir -p /boot/firmware
           # Install packages that the playbook expects (present on RPi OS but not Debian cloud)
-          sudo apt-get update -qq && sudo apt-get install -y -qq cron logrotate
+          sudo apt-get update -qq && sudo apt-get install -y -qq cron logrotate rsync
+          # Create restore logs to skip backup restore tasks (backup server is unreachable in CI)
+          sudo touch /var/log/restore-prometheus.log /var/log/restore-hass.log
           # Pre-populate config.txt with the content the playbook would write (blockinfile)
           printf '%s\n' '# BEGIN ANSIBLE MANAGED BLOCK' 'hdmi_ignore_cec_init=1' '# END ANSIBLE MANAGED BLOCK' | sudo tee /boot/firmware/config.txt
           # Pre-populate cmdline.txt with the content the playbook would write (lineinfile)

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   ansible-raspberry-pi-os-test:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
       run:
@@ -48,45 +48,84 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq ansible python3-passlib sshpass
+          sudo apt-get install -y -qq ansible python3-passlib qemu-system-x86 qemu-utils cloud-image-utils sshpass
 
-      - name: Start Debian container (Raspberry Pi OS base)
+      - name: Download Debian cloud image
         run: |
-          # Run Debian bookworm (same base as Raspberry Pi OS) with SSH
-          docker run -d --name raspi-test \
-            -p 2222:22 \
-            --tmpfs /run \
-            --tmpfs /run/lock \
-            debian:bookworm \
-            bash -c '
-              apt-get update -qq &&
-              apt-get install -y -qq openssh-server sudo python3 systemd &&
-              useradd -m -s /bin/bash pi &&
-              echo "pi:raspberry" | chpasswd &&
-              echo "pi ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/pi &&
-              mkdir -p /run/sshd &&
-              sed -i "s/^#*PasswordAuthentication.*/PasswordAuthentication yes/" /etc/ssh/sshd_config &&
-              /usr/sbin/sshd -D
-            '
+          CLOUD_IMAGE_URL="https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
+          curl -sL -o debian-cloud.qcow2 "${CLOUD_IMAGE_URL}"
+          # Resize to 10GB for package installs
+          qemu-img resize debian-cloud.qcow2 10G
 
-          # Wait for SSH to become available
+      - name: Prepare cloud-init and boot VM
+        run: |
+          # Generate SSH key for Ansible
+          ssh-keygen -t ed25519 -f "${HOME}/.ssh/id_ed25519" -N "" -q
+
+          # Create cloud-init user-data
+          cat > user-data <<'USERDATA'
+          #cloud-config
+          users:
+            - name: pi
+              plain_text_passwd: raspberry
+              lock_passwd: false
+              sudo: ALL=(ALL) NOPASSWD:ALL
+              shell: /bin/bash
+              ssh_authorized_keys:
+                - SSH_PUB_KEY_PLACEHOLDER
+          ssh_pwauth: true
+          package_update: true
+          packages:
+            - python3
+          USERDATA
+
+          # Inject the actual SSH public key
+          SSH_PUB_KEY=$(cat "${HOME}/.ssh/id_ed25519.pub")
+          sed -i "s|SSH_PUB_KEY_PLACEHOLDER|${SSH_PUB_KEY}|" user-data
+
+          # Remove leading whitespace from heredoc (YAML indentation artifact)
+          sed -i 's/^          //' user-data
+
+          # Create cloud-init ISO
+          cloud-localds seed.img user-data
+
+          # Verify KVM is available
+          ls -la /dev/kvm
+          sudo chmod 666 /dev/kvm
+
+          # Boot VM with KVM acceleration
+          qemu-system-x86_64 \
+            -machine q35 -accel kvm -cpu host -m 4096 -smp 4 \
+            -drive file=debian-cloud.qcow2,if=virtio,format=qcow2 \
+            -drive file=seed.img,if=virtio,format=raw \
+            -device virtio-net-pci,netdev=net0 \
+            -netdev user,id=net0,hostfwd=tcp::2222-:22 \
+            -nographic \
+            -no-reboot &
+
+          QEMU_PID=$!
+          echo "QEMU_PID=${QEMU_PID}" >> "${GITHUB_ENV}"
+
+          # Wait for SSH (cloud-init needs time to configure the VM)
           echo "Waiting for SSH to become available..."
-          for I in $(seq 1 30); do
+          for I in $(seq 1 60); do
             if sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@localhost echo "SSH is ready" 2>/dev/null; then
               echo "SSH is ready after ${I} attempts"
               break
             fi
-            echo "Attempt ${I}/30 - waiting 2s..."
-            sleep 2
+            if ! kill -0 "${QEMU_PID}" 2>/dev/null; then
+              echo "QEMU process died"
+              exit 1
+            fi
+            echo "Attempt ${I}/60 - waiting 5s..."
+            sleep 5
           done
 
-          # Verify SSH connectivity
+          # Verify connectivity
           sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@localhost uname -a
 
       - name: Create test inventory
         run: |
-          # Generate SSH key (required by Ansible pre_tasks)
-          ssh-keygen -t ed25519 -f "${HOME}/.ssh/id_ed25519" -N "" -q
           printf '%s\n' \
             "[raspberry_pi]" \
             "localhost" \
@@ -108,7 +147,9 @@ jobs:
         working-directory: ansible
         run: ansible-playbook --diff --user root -i inventory/test-hosts main.yml
 
-      - name: Stop container
+      - name: Stop QEMU
         if: always()
         run: |
-          docker rm -f raspi-test 2>/dev/null || true
+          if [ -n "${QEMU_PID:-}" ]; then
+            kill "${QEMU_PID}" 2>/dev/null || true
+          fi

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   ansible-raspberry-pi-os-test:
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 15
     defaults:
       run:
@@ -48,7 +48,8 @@ jobs:
 
       - name: Install QEMU and dependencies
         run: |
-          brew install --quiet ansible qemu mtools hudochenkov/sshpass/sshpass xz
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ansible mtools qemu-system-arm qemu-efi-aarch64 qemu-utils sshpass xz-utils
 
       - name: Download latest Raspberry Pi OS image
         run: |
@@ -126,15 +127,15 @@ jobs:
 
       - name: Boot Raspberry Pi OS in QEMU
         run: |
-          UEFI_FW="$(brew --prefix qemu)/share/qemu/edk2-aarch64-code.fd"
+          UEFI_FW="/usr/share/qemu-efi-aarch64/QEMU_EFI.fd"
 
           # Create writable copies of UEFI firmware
           cp "${UEFI_FW}" flash0.img
-          dd if=/dev/zero of=flash1.img bs=1m count=64
+          dd if=/dev/zero of=flash1.img bs=1M count=64
 
-          # Start QEMU in background with TCG software emulation
+          # Start QEMU in background with KVM hardware virtualization
           qemu-system-aarch64 \
-            -machine virt,highmem=on -accel tcg -cpu cortex-a72 -m 4096 -smp 3 \
+            -machine virt,highmem=on -accel kvm -cpu host -m 4096 -smp 3 \
             -drive if=pflash,format=raw,file=flash0.img,readonly=on \
             -drive if=pflash,format=raw,file=flash1.img \
             -drive if=virtio,file=raspios.qcow2,format=qcow2 \

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -129,8 +129,9 @@ jobs:
         run: |
           UEFI_FW="/usr/share/qemu-efi-aarch64/QEMU_EFI.fd"
 
-          # Create writable copies of UEFI firmware
-          cp "${UEFI_FW}" flash0.img
+          # Create 64MB pflash images (QEMU requires exact size)
+          dd if=/dev/zero of=flash0.img bs=1M count=64
+          dd if="${UEFI_FW}" of=flash0.img conv=notrunc
           dd if=/dev/zero of=flash1.img bs=1M count=64
 
           # Start QEMU in background with TCG emulation (KVM not available on GitHub runners)

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -170,6 +170,8 @@ jobs:
             printf '[Unit]\nDescription=Dummy %s\n[Service]\nType=oneshot\nExecStart=/bin/true\n[Install]\nWantedBy=multi-user.target\n' "${SVC}" | sudo tee "/etc/systemd/system/${SVC}.service"
           done
           sudo systemctl daemon-reload
+          # Start a dummy listener on port 8080 (Kodi web server won't start in headless VM)
+          nohup sudo python3 -c 'import http.server; http.server.HTTPServer(("", 8080), http.server.BaseHTTPRequestHandler).serve_forever()' &
           REMOTE_SCRIPT
 
           # Export VM's existing SSH host key so the playbook writes a valid key

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -148,7 +148,7 @@ jobs:
 
           # Start QEMU in background with TCG software emulation
           qemu-system-aarch64 \
-            -machine virt,highmem=on -accel tcg -cpu cortex-a72 -m 2048 -smp 2 \
+            -machine virt,highmem=on -accel tcg -cpu cortex-a72 -m 4096 -smp 3 \
             -drive if=pflash,format=raw,file=flash0.img,readonly=on \
             -drive if=pflash,format=raw,file=flash1.img \
             -drive if=virtio,file=raspios.qcow2,format=qcow2 \

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -8,7 +8,6 @@ on:
 permissions: read-all
 
 env:
-  RASPIOS_BASE_URL: "https://downloads.raspberrypi.com/raspios_lite_arm64/images"
   # Dummy secrets for testing (no real credentials needed)
   ALLOY_GRAFANA_CLOUD_PASSWORD: dummy-alloy-password
   BLUETOOTH_IDENTITY_RESOLVING_KEY: "0000000000000000"
@@ -38,7 +37,7 @@ env:
 jobs:
   ansible-raspberry-pi-os-test:
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 15
+    timeout-minutes: 30
     defaults:
       run:
         shell: bash -euxo pipefail {0}
@@ -46,143 +45,60 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install QEMU and dependencies
+      - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq ansible mtools qemu-system-arm qemu-efi-aarch64 qemu-utils sshpass xz-utils
+          sudo apt-get install -y -qq ansible sshpass
 
-      - name: Download latest Raspberry Pi OS image
+      - name: Start Debian container (Raspberry Pi OS base)
         run: |
-          LATEST_DIR=$(curl -sL "${RASPIOS_BASE_URL}/" | grep -oE 'raspios_lite_arm64-[0-9]{4}-[0-9]{2}-[0-9]{2}' | tail -1)
-          RASPIOS_IMAGE_URL="${RASPIOS_BASE_URL}/${LATEST_DIR}/$(curl -sL "${RASPIOS_BASE_URL}/${LATEST_DIR}/" | grep -oE '[^"]+\.img\.xz' | head -1)"
-          echo "Downloading: ${RASPIOS_IMAGE_URL}"
-          curl -sL "${RASPIOS_IMAGE_URL}" | xz -d > raspios.img
+          # Run Debian bookworm (same base as Raspberry Pi OS) with SSH
+          docker run -d --name raspi-test \
+            -p 2222:22 \
+            --tmpfs /run \
+            --tmpfs /run/lock \
+            debian:bookworm \
+            bash -c '
+              apt-get update -qq &&
+              apt-get install -y -qq openssh-server sudo python3 systemd &&
+              useradd -m -s /bin/bash pi &&
+              echo "pi:raspberry" | chpasswd &&
+              echo "pi ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/pi &&
+              mkdir -p /run/sshd &&
+              sed -i "s/^#*PasswordAuthentication.*/PasswordAuthentication yes/" /etc/ssh/sshd_config &&
+              /usr/sbin/sshd -D
+            '
 
-      - name: Prepare image for QEMU
-        run: |
-          IMAGE_FILE="raspios.img"
-
-          # Resize image to give more space for packages
-          qemu-img resize -f raw "${IMAGE_FILE}" 8G
-
-          # Parse MBR partition table to find partition offsets
-          # shellcheck disable=SC2034
-          PARTITIONS=$(python3 -c "
-          import struct
-          with open('${IMAGE_FILE}', 'rb') as f:
-              f.seek(446)
-              for i in range(4):
-                  entry = f.read(16)
-                  if len(entry) < 16:
-                      break
-                  ptype = entry[4]
-                  lba_start = struct.unpack('<I', entry[8:12])[0]
-                  lba_size = struct.unpack('<I', entry[12:16])[0]
-                  if lba_size > 0:
-                      print(f'{i+1} {ptype} {lba_start} {lba_size}')
-          ")
-
-          BOOT_START=$(echo "${PARTITIONS}" | awk 'NR==1{print $3}')
-          ROOT_START=$(echo "${PARTITIONS}" | awk 'NR==2{print $3}')
-
-          BOOT_OFFSET_BYTES=$((BOOT_START * 512))
-
-          echo "Boot partition: start=${BOOT_START} sectors"
-          echo "Root partition: start=${ROOT_START} sectors"
-
-          # Enable SSH by creating the ssh file in boot partition
-          touch ssh_marker && mcopy -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" ssh_marker ::ssh && rm ssh_marker
-
-          # Create userconf.txt for pi user with password 'raspberry'
-          ENCRYPTED_PASS=$(openssl passwd -5 raspberry)
-          echo "pi:${ENCRYPTED_PASS}" > userconf.txt
-          mcopy -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" userconf.txt ::userconf.txt && rm userconf.txt
-
-          # Create firstrun.sh to enable password authentication
-          cat > firstrun.sh <<'FIRSTRUN'
-          #!/bin/bash
-          set -e
-          sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
-          systemctl restart ssh
-          rm -f /boot/firmware/firstrun.sh
-          FIRSTRUN
-          chmod +x firstrun.sh
-          mcopy -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" firstrun.sh ::firstrun.sh && rm firstrun.sh
-
-          # Read cmdline.txt, append firstrun.sh reference, and write back
-          mcopy -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" ::cmdline.txt cmdline.txt
-          if ! grep -q "firstrun.sh" cmdline.txt 2>/dev/null; then
-            # Append systemd.run directive (remove trailing newline first)
-            tr -d '\n' < cmdline.txt > cmdline_tmp.txt
-            echo " systemd.run=/boot/firmware/firstrun.sh systemd.run_success_action=none systemd.unit=kernel-command-line.target" >> cmdline_tmp.txt
-            mcopy -o -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" cmdline_tmp.txt ::cmdline.txt
-            rm cmdline.txt cmdline_tmp.txt
-          else
-            rm cmdline.txt
-          fi
-
-          # Convert image to qcow2 for better performance
-          qemu-img convert -f raw -O qcow2 "${IMAGE_FILE}" raspios.qcow2
-          rm "${IMAGE_FILE}"
-
-      - name: Boot Raspberry Pi OS in QEMU
-        run: |
-          UEFI_FW="/usr/share/qemu-efi-aarch64/QEMU_EFI.fd"
-
-          # Create 64MB pflash images (QEMU requires exact size)
-          dd if=/dev/zero of=flash0.img bs=1M count=64
-          dd if="${UEFI_FW}" of=flash0.img conv=notrunc
-          dd if=/dev/zero of=flash1.img bs=1M count=64
-
-          # Start QEMU in background with TCG emulation (KVM not available on GitHub runners)
-          qemu-system-aarch64 \
-            -machine virt,highmem=on -accel tcg,thread=multi -cpu cortex-a72 -m 4096 -smp 4 \
-            -drive if=pflash,format=raw,file=flash0.img,readonly=on \
-            -drive if=pflash,format=raw,file=flash1.img \
-            -drive if=virtio,file=raspios.qcow2,format=qcow2 \
-            -device virtio-net-pci,netdev=net0,romfile= \
-            -netdev user,id=net0,hostfwd=tcp::2222-:22 \
-            -nographic \
-            -no-reboot &
-
-          QEMU_PID=$!
-          echo "QEMU_PID=${QEMU_PID}" >> "${GITHUB_ENV}"
-
-          # Wait for SSH to become available (timeout 5 minutes)
+          # Wait for SSH to become available
           echo "Waiting for SSH to become available..."
-          for I in $(seq 1 60); do
+          for I in $(seq 1 30); do
             if sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@localhost echo "SSH is ready" 2>/dev/null; then
               echo "SSH is ready after ${I} attempts"
               break
             fi
-            if ! kill -0 "${QEMU_PID}" 2>/dev/null; then
-              echo "QEMU process died"
-              exit 1
-            fi
-            echo "Attempt ${I}/60 - waiting 5s..."
-            sleep 5
+            echo "Attempt ${I}/30 - waiting 2s..."
+            sleep 2
           done
 
           # Verify SSH connectivity
           sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@localhost uname -a
 
-          # Resize root partition inside the VM
-          sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@localhost \
-            "sudo growpart /dev/vda 2 && sudo resize2fs /dev/vda2" || true
-
       - name: Create test inventory
         run: |
-          cat > ansible/inventory/test-hosts <<'EOF'
-          [raspberry_pi]
-          localhost
-
-          [raspberry_pi:vars]
-          ansible_user=pi
-          ansible_ssh_pass=raspberry
-          ansible_port=2222
-          ansible_python_interpreter=/usr/bin/python3
-          ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
-          EOF
+          # Generate SSH key (required by Ansible pre_tasks)
+          ssh-keygen -t ed25519 -f "${HOME}/.ssh/id_ed25519" -N "" -q
+          printf '%s\n' \
+            "[raspberry_pi]" \
+            "localhost" \
+            "" \
+            "[raspberry_pi:vars]" \
+            "ansible_user=pi" \
+            "ansible_ssh_pass=raspberry" \
+            "ansible_become_password=raspberry" \
+            "ansible_port=2222" \
+            "ansible_python_interpreter=/usr/bin/python3" \
+            "ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+            > ansible/inventory/test-hosts
 
       - name: Install Ansible Galaxy dependencies
         working-directory: ansible
@@ -192,9 +108,7 @@ jobs:
         working-directory: ansible
         run: ansible-playbook --diff --user root -i inventory/test-hosts main.yml
 
-      - name: Stop QEMU
+      - name: Stop container
         if: always()
         run: |
-          if [ -n "${QEMU_PID:-}" ]; then
-            kill "${QEMU_PID}" 2>/dev/null || true
-          fi
+          docker rm -f raspi-test 2>/dev/null || true

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install QEMU and dependencies
         run: |
-          brew install --quiet qemu e2fsprogs hudochenkov/sshpass/sshpass xz
+          brew install --quiet qemu e2fsprogs mtools hudochenkov/sshpass/sshpass xz
 
       - name: Download latest Raspberry Pi OS image
         run: |
@@ -82,47 +82,46 @@ jobs:
           ")
 
           BOOT_START=$(echo "${PARTITIONS}" | awk 'NR==1{print $3}')
-          BOOT_SIZE=$(echo "${PARTITIONS}" | awk 'NR==1{print $4}')
           ROOT_START=$(echo "${PARTITIONS}" | awk 'NR==2{print $3}')
 
           BOOT_OFFSET_BYTES=$((BOOT_START * 512))
-          BOOT_SIZE_BYTES=$((BOOT_SIZE * 512))
 
-          echo "Boot partition: start=${BOOT_START}, size=${BOOT_SIZE} sectors"
+          echo "Boot partition: start=${BOOT_START} sectors"
           echo "Root partition: start=${ROOT_START} sectors"
 
-          # Mount FAT32 boot partition using hdiutil
-          BOOT_DEV=$(hdiutil attach -nomount -imagekey diskimage-class=CRawDiskImage -section "${BOOT_OFFSET_BYTES},${BOOT_SIZE_BYTES}" "${IMAGE_FILE}" | awk '{print $1}')
-          BOOT_MOUNT=$(mktemp -d)
-          mount -t msdos "${BOOT_DEV}" "${BOOT_MOUNT}"
+          # Configure mtools to access boot partition at correct offset
+          echo "drive x: file=\"${IMAGE_FILE}\" offset=${BOOT_OFFSET_BYTES}" > ~/.mtoolsrc
 
           # Enable SSH by creating the ssh file in boot partition
-          touch "${BOOT_MOUNT}/ssh"
+          touch ssh_marker && mcopy -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" ssh_marker ::ssh && rm ssh_marker
 
           # Create userconf.txt for pi user with password 'raspberry'
           ENCRYPTED_PASS=$(python3 -c "import crypt; print(crypt.crypt('raspberry', crypt.mksalt(crypt.METHOD_SHA256)))")
-          echo "pi:${ENCRYPTED_PASS}" > "${BOOT_MOUNT}/userconf.txt"
+          echo "pi:${ENCRYPTED_PASS}" > userconf.txt
+          mcopy -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" userconf.txt ::userconf.txt && rm userconf.txt
 
           # Create firstrun.sh to enable password authentication
-          cat > "${BOOT_MOUNT}/firstrun.sh" <<'FIRSTRUN'
+          cat > firstrun.sh <<'FIRSTRUN'
           #!/bin/bash
           set -e
           sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
           systemctl restart ssh
           rm -f /boot/firmware/firstrun.sh
           FIRSTRUN
-          chmod +x "${BOOT_MOUNT}/firstrun.sh"
+          chmod +x firstrun.sh
+          mcopy -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" firstrun.sh ::firstrun.sh && rm firstrun.sh
 
-          # Add firstrun.sh to cmdline.txt if not already present
-          if ! grep -q "firstrun.sh" "${BOOT_MOUNT}/cmdline.txt" 2>/dev/null; then
-            CMDLINE=$(cat "${BOOT_MOUNT}/cmdline.txt")
-            echo "${CMDLINE} systemd.run=/boot/firmware/firstrun.sh systemd.run_success_action=none systemd.unit=kernel-command-line.target" > "${BOOT_MOUNT}/cmdline.txt"
+          # Read cmdline.txt, append firstrun.sh reference, and write back
+          mcopy -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" ::cmdline.txt cmdline.txt
+          if ! grep -q "firstrun.sh" cmdline.txt 2>/dev/null; then
+            # Append systemd.run directive (remove trailing newline first)
+            tr -d '\n' < cmdline.txt > cmdline_tmp.txt
+            echo " systemd.run=/boot/firmware/firstrun.sh systemd.run_success_action=none systemd.unit=kernel-command-line.target" >> cmdline_tmp.txt
+            mcopy -o -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" cmdline_tmp.txt ::cmdline.txt
+            rm cmdline.txt cmdline_tmp.txt
+          else
+            rm cmdline.txt
           fi
-
-          # Unmount boot partition
-          umount "${BOOT_MOUNT}"
-          hdiutil detach "${BOOT_DEV}"
-          rmdir "${BOOT_MOUNT}"
 
           # Modify sshd_config on root partition (ext4) using debugfs
           E2FSPROGS_PREFIX="$(brew --prefix e2fsprogs)"

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -159,6 +159,10 @@ jobs:
           printf '%s\n' '# BEGIN ANSIBLE MANAGED BLOCK' 'hdmi_ignore_cec_init=1' '# END ANSIBLE MANAGED BLOCK' | sudo tee /boot/firmware/config.txt
           # Pre-populate cmdline.txt with the content the playbook would write (lineinfile)
           echo 'console=tty1 root=/dev/vda1 cgroup_enable=cpuset cgroup_enable=memory psi=1' | sudo tee /boot/firmware/cmdline.txt
+          # Create groups that the playbook expects (present on RPi OS but not Debian cloud)
+          sudo groupadd -f bluetooth
+          sudo groupadd -f input
+          sudo groupadd -f plugdev
           # Create sshd service alias (Debian uses 'ssh', RPi OS uses 'sshd')
           sudo ln -sf /lib/systemd/system/ssh.service /etc/systemd/system/sshd.service
           # Create dummy systemd units for RPi OS-specific services that the playbook disables

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -155,6 +155,14 @@ jobs:
           sudo systemctl daemon-reload
           REMOTE_SCRIPT
 
+          # Export VM's existing SSH host key so the playbook writes a valid key
+          SSH_HOST_KEY=$(sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@127.0.0.1 "sudo cat /etc/ssh/ssh_host_ed25519_key")
+          {
+            echo "SSH_HOST_ED25519_KEY<<SSHEOF"
+            echo "${SSH_HOST_KEY}"
+            echo "SSHEOF"
+          } >> "${GITHUB_ENV}"
+
       - name: Install Ansible Galaxy dependencies
         working-directory: ansible
         run: ansible-galaxy install -r requirements.yml

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -101,8 +101,7 @@ jobs:
             -drive file=seed.img,if=virtio,format=raw \
             -device virtio-net-pci,netdev=net0 \
             -netdev user,id=net0,hostfwd=tcp::2222-:22 \
-            -nographic \
-            -no-reboot &
+            -nographic &
 
           QEMU_PID=$!
           echo "QEMU_PID=${QEMU_PID}" >> "${GITHUB_ENV}"

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -38,7 +38,7 @@ env:
 jobs:
   ansible-raspberry-pi-os-test:
     runs-on: macos-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
     defaults:
       run:
         shell: bash -euxo pipefail {0}

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -122,7 +122,7 @@ jobs:
             -drive if=pflash,format=raw,file=flash0.img,readonly=on \
             -drive if=pflash,format=raw,file=flash1.img \
             -drive if=virtio,file=raspios.qcow2,format=qcow2 \
-            -device virtio-net-pci,netdev=net0 \
+            -device virtio-net-pci,netdev=net0,romfile= \
             -netdev user,id=net0,hostfwd=tcp::2222-:22 \
             -nographic \
             -no-reboot &

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install QEMU and dependencies
         run: |
-          brew install --quiet qemu e2fsprogs mtools hudochenkov/sshpass/sshpass xz
+          brew install --quiet ansible qemu mtools xz
 
       - name: Download latest Raspberry Pi OS image
         run: |
@@ -60,6 +60,10 @@ jobs:
       - name: Prepare image for QEMU
         run: |
           IMAGE_FILE="raspios.img"
+
+          # Generate SSH keypair for authentication
+          ssh-keygen -t ed25519 -f "${HOME}/.ssh/qemu_key" -N "" -q
+          SSH_PUBKEY=$(cat "${HOME}/.ssh/qemu_key.pub")
 
           # Resize image to give more space for packages
           qemu-img resize -f raw "${IMAGE_FILE}" 8G
@@ -89,9 +93,6 @@ jobs:
           echo "Boot partition: start=${BOOT_START} sectors"
           echo "Root partition: start=${ROOT_START} sectors"
 
-          # Configure mtools to access boot partition at correct offset
-          echo "drive x: file=\"${IMAGE_FILE}\" offset=${BOOT_OFFSET_BYTES}" > ~/.mtoolsrc
-
           # Enable SSH by creating the ssh file in boot partition
           touch ssh_marker && mcopy -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" ssh_marker ::ssh && rm ssh_marker
 
@@ -100,12 +101,15 @@ jobs:
           echo "pi:${ENCRYPTED_PASS}" > userconf.txt
           mcopy -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" userconf.txt ::userconf.txt && rm userconf.txt
 
-          # Create firstrun.sh to enable password authentication
-          cat > firstrun.sh <<'FIRSTRUN'
+          # Create firstrun.sh to inject SSH public key for pi user
+          cat > firstrun.sh <<FIRSTRUN
           #!/bin/bash
           set -e
-          sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
-          systemctl restart ssh
+          mkdir -p /home/pi/.ssh
+          echo "${SSH_PUBKEY}" > /home/pi/.ssh/authorized_keys
+          chmod 700 /home/pi/.ssh
+          chmod 600 /home/pi/.ssh/authorized_keys
+          chown -R pi:pi /home/pi/.ssh
           rm -f /boot/firmware/firstrun.sh
           FIRSTRUN
           chmod +x firstrun.sh
@@ -121,17 +125,6 @@ jobs:
             rm cmdline.txt cmdline_tmp.txt
           else
             rm cmdline.txt
-          fi
-
-          # Modify sshd_config on root partition (ext4) using debugfs
-          E2FSPROGS_PREFIX="$(brew --prefix e2fsprogs)"
-          SSHD_CONFIG=$("${E2FSPROGS_PREFIX}/sbin/debugfs" -R "cat etc/ssh/sshd_config" -f /dev/stdin "${IMAGE_FILE}" -b 512 -s "${ROOT_START}" 2>/dev/null || true)
-          if [ -n "${SSHD_CONFIG}" ]; then
-            MODIFIED_CONFIG="${SSHD_CONFIG//\#*PasswordAuthentication*/PasswordAuthentication yes}"
-            TMPFILE=$(mktemp)
-            echo "${MODIFIED_CONFIG}" > "${TMPFILE}"
-            echo "write ${TMPFILE} etc/ssh/sshd_config" | "${E2FSPROGS_PREFIX}/sbin/debugfs" -w "${IMAGE_FILE}" -b 512 -s "${ROOT_START}" 2>/dev/null || true
-            rm -f "${TMPFILE}"
           fi
 
           # Convert image to qcow2 for better performance
@@ -160,10 +153,13 @@ jobs:
           QEMU_PID=$!
           echo "QEMU_PID=${QEMU_PID}" >> "${GITHUB_ENV}"
 
+          SSH_OPTS="-i ${HOME}/.ssh/qemu_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
           # Wait for SSH to become available (timeout 5 minutes)
           echo "Waiting for SSH to become available..."
           for I in $(seq 1 60); do
-            if sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@localhost echo "SSH is ready" 2>/dev/null; then
+            # shellcheck disable=SC2086
+            if ssh ${SSH_OPTS} -p 2222 pi@localhost echo "SSH is ready" 2>/dev/null; then
               echo "SSH is ready after ${I} attempts"
               break
             fi
@@ -176,15 +172,13 @@ jobs:
           done
 
           # Verify SSH connectivity
-          sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@localhost uname -a
+          # shellcheck disable=SC2086
+          ssh ${SSH_OPTS} -p 2222 pi@localhost uname -a
 
           # Resize root partition inside the VM
-          sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@localhost \
+          # shellcheck disable=SC2086
+          ssh ${SSH_OPTS} -p 2222 pi@localhost \
             "sudo growpart /dev/vda 2 && sudo resize2fs /dev/vda2" || true
-
-      - name: Install Ansible
-        run: |
-          brew install --quiet ansible
 
       - name: Create test inventory
         run: |
@@ -194,7 +188,7 @@ jobs:
 
           [raspberry_pi:vars]
           ansible_user=pi
-          ansible_ssh_pass=raspberry
+          ansible_ssh_private_key_file=~/.ssh/qemu_key
           ansible_port=2222
           ansible_python_interpreter=/usr/bin/python3
           ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq ansible python3-passlib qemu-system-x86 qemu-utils cloud-image-utils sshpass
-          pip install --break-system-packages passlib
+          sudo apt-get install -y -qq qemu-system-x86 qemu-utils cloud-image-utils sshpass
+          pip install --break-system-packages ansible passlib
 
       - name: Download Debian cloud image
         run: |

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -140,6 +140,13 @@ jobs:
             "ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
             > ansible/inventory/test-hosts
 
+      - name: Prepare VM for Ansible playbook
+        run: |
+          # Create Raspberry Pi-specific files that the playbook expects
+          sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@127.0.0.1 "sudo mkdir -p /boot/firmware && echo '' | sudo tee /boot/firmware/config.txt && echo 'console=tty1 root=/dev/vda1' | sudo tee /boot/firmware/cmdline.txt"
+          # Create sshd service alias (Debian uses 'ssh', RPi OS uses 'sshd')
+          sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@127.0.0.1 "sudo ln -sf /lib/systemd/system/ssh.service /etc/systemd/system/sshd.service && sudo systemctl daemon-reload"
+
       - name: Install Ansible Galaxy dependencies
         working-directory: ansible
         run: ansible-galaxy install -r requirements.yml

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq ansible python3-passlib qemu-system-x86 qemu-utils cloud-image-utils sshpass
+          pip install --break-system-packages passlib
 
       - name: Download Debian cloud image
         run: |

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   ansible-raspberry-pi-os-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash -euxo pipefail {0}

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -153,8 +153,10 @@ jobs:
           # Pre-install GPG keys for Docker and Mosquitto repos
           # Docker key is armored and needs dearmoring for deb822 signed_by
           curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
-          # Mosquitto key is already binary, just download it directly
-          sudo curl -fsSL -o /etc/apt/trusted.gpg.d/mosquitto-repo.asc https://repo.mosquitto.org/debian/mosquitto-repo.gpg
+          # Mosquitto key is binary but the playbook saves it with .asc extension
+          # Convert to armored format matching the .asc extension
+          # get_url won't overwrite since the file already exists
+          curl -fsSL https://repo.mosquitto.org/debian/mosquitto-repo.gpg | sudo gpg --enarmor | sudo sed 's/ARMORED FILE/PUBLIC KEY BLOCK/' | sudo tee /etc/apt/trusted.gpg.d/mosquitto-repo.asc > /dev/null
           # Create restore logs to skip backup restore tasks (backup server is unreachable in CI)
           sudo touch /var/log/restore-prometheus.log /var/log/restore-hass.log
           # Pre-populate config.txt with the content the playbook would write (blockinfile)

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -146,6 +146,8 @@ jobs:
           # The playbook uses blockinfile for config.txt and lineinfile for cmdline.txt
           sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@127.0.0.1 bash -s <<'REMOTE_SCRIPT'
           sudo mkdir -p /boot/firmware
+          # Install packages that the playbook expects (present on RPi OS but not Debian cloud)
+          sudo apt-get update -qq && sudo apt-get install -y -qq logrotate
           # Pre-populate config.txt with the content the playbook would write (blockinfile)
           printf '%s\n' '# BEGIN ANSIBLE MANAGED BLOCK' 'hdmi_ignore_cec_init=1' '# END ANSIBLE MANAGED BLOCK' | sudo tee /boot/firmware/config.txt
           # Pre-populate cmdline.txt with the content the playbook would write (lineinfile)

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -150,10 +150,11 @@ jobs:
           sudo mkdir -p /boot/firmware
           # Install packages that the playbook expects (present on RPi OS but not Debian cloud)
           sudo apt-get update -qq && sudo apt-get install -y -qq cron gnupg logrotate rsync
-          # Pre-install dearmored GPG keys for Docker and Mosquitto repos
-          # The playbook downloads armored keys via get_url but deb822 signed_by needs dearmored keys
+          # Pre-install GPG keys for Docker and Mosquitto repos
+          # Docker key is armored and needs dearmoring for deb822 signed_by
           curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
-          curl -fsSL https://repo.mosquitto.org/debian/mosquitto-repo.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/mosquitto-repo.asc
+          # Mosquitto key is already binary, just download it directly
+          sudo curl -fsSL -o /etc/apt/trusted.gpg.d/mosquitto-repo.asc https://repo.mosquitto.org/debian/mosquitto-repo.gpg
           # Create restore logs to skip backup restore tasks (backup server is unreachable in CI)
           sudo touch /var/log/restore-prometheus.log /var/log/restore-hass.log
           # Pre-populate config.txt with the content the playbook would write (blockinfile)

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -147,7 +147,7 @@ jobs:
           sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@127.0.0.1 bash -s <<'REMOTE_SCRIPT'
           sudo mkdir -p /boot/firmware
           # Pre-populate config.txt with the content the playbook would write (blockinfile)
-          printf '%s\n' '# BEGIN ANSIBLE MANAGED BLOCK' 'hdmi_ignore_cec_init=1' '' '# END ANSIBLE MANAGED BLOCK' | sudo tee /boot/firmware/config.txt
+          printf '%s\n' '# BEGIN ANSIBLE MANAGED BLOCK' 'hdmi_ignore_cec_init=1' '# END ANSIBLE MANAGED BLOCK' | sudo tee /boot/firmware/config.txt
           # Pre-populate cmdline.txt with the content the playbook would write (lineinfile)
           echo 'console=tty1 root=/dev/vda1 cgroup_enable=cpuset cgroup_enable=memory psi=1' | sudo tee /boot/firmware/cmdline.txt
           # Create sshd service alias (Debian uses 'ssh', RPi OS uses 'sshd')

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -133,9 +133,9 @@ jobs:
           cp "${UEFI_FW}" flash0.img
           dd if=/dev/zero of=flash1.img bs=1M count=64
 
-          # Start QEMU in background with KVM hardware virtualization
+          # Start QEMU in background with TCG emulation (KVM not available on GitHub runners)
           qemu-system-aarch64 \
-            -machine virt,highmem=on -accel kvm -cpu host -m 4096 -smp 3 \
+            -machine virt,highmem=on -accel tcg,thread=multi -cpu cortex-a72 -m 4096 -smp 4 \
             -drive if=pflash,format=raw,file=flash0.img,readonly=on \
             -drive if=pflash,format=raw,file=flash1.img \
             -drive if=virtio,file=raspios.qcow2,format=qcow2 \

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq ansible sshpass
+          sudo apt-get install -y -qq ansible python3-passlib sshpass
 
       - name: Start Debian container (Raspberry Pi OS base)
         run: |

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -147,7 +147,7 @@ jobs:
           sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@127.0.0.1 bash -s <<'REMOTE_SCRIPT'
           sudo mkdir -p /boot/firmware
           # Install packages that the playbook expects (present on RPi OS but not Debian cloud)
-          sudo apt-get update -qq && sudo apt-get install -y -qq logrotate
+          sudo apt-get update -qq && sudo apt-get install -y -qq cron logrotate
           # Pre-populate config.txt with the content the playbook would write (blockinfile)
           printf '%s\n' '# BEGIN ANSIBLE MANAGED BLOCK' 'hdmi_ignore_cec_init=1' '# END ANSIBLE MANAGED BLOCK' | sudo tee /boot/firmware/config.txt
           # Pre-populate cmdline.txt with the content the playbook would write (lineinfile)

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -101,7 +101,8 @@ jobs:
             -drive file=seed.img,if=virtio,format=raw \
             -device virtio-net-pci,netdev=net0 \
             -netdev user,id=net0,hostfwd=tcp::2222-:22 \
-            -nographic &
+            -nographic \
+            -no-reboot &
 
           QEMU_PID=$!
           echo "QEMU_PID=${QEMU_PID}" >> "${GITHUB_ENV}"
@@ -141,10 +142,18 @@ jobs:
 
       - name: Prepare VM for Ansible playbook
         run: |
-          # Create Raspberry Pi-specific files that the playbook expects
-          sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@127.0.0.1 "sudo mkdir -p /boot/firmware && echo '' | sudo tee /boot/firmware/config.txt && echo 'console=tty1 root=/dev/vda1' | sudo tee /boot/firmware/cmdline.txt"
+          # Create Raspberry Pi-specific files with expected content to prevent unnecessary reboot
+          # The playbook uses blockinfile for config.txt and lineinfile for cmdline.txt
+          sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@127.0.0.1 bash -s <<'REMOTE_SCRIPT'
+          sudo mkdir -p /boot/firmware
+          # Pre-populate config.txt with the content the playbook would write (blockinfile)
+          printf '%s\n' '# BEGIN ANSIBLE MANAGED BLOCK' 'hdmi_ignore_cec_init=1' '' '# END ANSIBLE MANAGED BLOCK' | sudo tee /boot/firmware/config.txt
+          # Pre-populate cmdline.txt with the content the playbook would write (lineinfile)
+          echo 'console=tty1 root=/dev/vda1 cgroup_enable=cpuset cgroup_enable=memory psi=1' | sudo tee /boot/firmware/cmdline.txt
           # Create sshd service alias (Debian uses 'ssh', RPi OS uses 'sshd')
-          sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@127.0.0.1 "sudo ln -sf /lib/systemd/system/ssh.service /etc/systemd/system/sshd.service && sudo systemctl daemon-reload"
+          sudo ln -sf /lib/systemd/system/ssh.service /etc/systemd/system/sshd.service
+          sudo systemctl daemon-reload
+          REMOTE_SCRIPT
 
       - name: Install Ansible Galaxy dependencies
         working-directory: ansible

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -146,9 +146,9 @@ jobs:
           cp "${UEFI_FW}" flash0.img
           dd if=/dev/zero of=flash1.img bs=1m count=64
 
-          # Start QEMU in background with HVF hardware virtualization
+          # Start QEMU in background with TCG software emulation
           qemu-system-aarch64 \
-            -machine virt,highmem=on -accel hvf -cpu host -m 2048 -smp 2 \
+            -machine virt,highmem=on -accel tcg -cpu cortex-a72 -m 2048 -smp 2 \
             -drive if=pflash,format=raw,file=flash0.img,readonly=on \
             -drive if=pflash,format=raw,file=flash1.img \
             -drive if=virtio,file=raspios.qcow2,format=qcow2 \
@@ -184,7 +184,7 @@ jobs:
 
       - name: Install Ansible
         run: |
-          pip3 install --break-system-packages ansible
+          brew install --quiet ansible
 
       - name: Create test inventory
         run: |

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install QEMU and dependencies
         run: |
-          brew install --quiet ansible qemu mtools xz
+          brew install --quiet ansible qemu mtools hudochenkov/sshpass/sshpass xz
 
       - name: Download latest Raspberry Pi OS image
         run: |
@@ -60,10 +60,6 @@ jobs:
       - name: Prepare image for QEMU
         run: |
           IMAGE_FILE="raspios.img"
-
-          # Generate SSH keypair for authentication
-          ssh-keygen -t ed25519 -f "${HOME}/.ssh/id_ed25519" -N "" -q
-          SSH_PUBKEY=$(cat "${HOME}/.ssh/id_ed25519.pub")
 
           # Resize image to give more space for packages
           qemu-img resize -f raw "${IMAGE_FILE}" 8G
@@ -101,15 +97,12 @@ jobs:
           echo "pi:${ENCRYPTED_PASS}" > userconf.txt
           mcopy -i "${IMAGE_FILE}@@${BOOT_OFFSET_BYTES}" userconf.txt ::userconf.txt && rm userconf.txt
 
-          # Create firstrun.sh to inject SSH public key for pi user
-          cat > firstrun.sh <<FIRSTRUN
+          # Create firstrun.sh to enable password authentication
+          cat > firstrun.sh <<'FIRSTRUN'
           #!/bin/bash
           set -e
-          mkdir -p /home/pi/.ssh
-          echo "${SSH_PUBKEY}" > /home/pi/.ssh/authorized_keys
-          chmod 700 /home/pi/.ssh
-          chmod 600 /home/pi/.ssh/authorized_keys
-          chown -R pi:pi /home/pi/.ssh
+          sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+          systemctl restart ssh
           rm -f /boot/firmware/firstrun.sh
           FIRSTRUN
           chmod +x firstrun.sh
@@ -153,13 +146,10 @@ jobs:
           QEMU_PID=$!
           echo "QEMU_PID=${QEMU_PID}" >> "${GITHUB_ENV}"
 
-          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-
           # Wait for SSH to become available (timeout 5 minutes)
           echo "Waiting for SSH to become available..."
           for I in $(seq 1 60); do
-            # shellcheck disable=SC2086
-            if ssh ${SSH_OPTS} -p 2222 pi@localhost echo "SSH is ready" 2>/dev/null; then
+            if sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@localhost echo "SSH is ready" 2>/dev/null; then
               echo "SSH is ready after ${I} attempts"
               break
             fi
@@ -172,12 +162,10 @@ jobs:
           done
 
           # Verify SSH connectivity
-          # shellcheck disable=SC2086
-          ssh ${SSH_OPTS} -p 2222 pi@localhost uname -a
+          sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@localhost uname -a
 
           # Resize root partition inside the VM
-          # shellcheck disable=SC2086
-          ssh ${SSH_OPTS} -p 2222 pi@localhost \
+          sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@localhost \
             "sudo growpart /dev/vda 2 && sudo resize2fs /dev/vda2" || true
 
       - name: Create test inventory
@@ -188,6 +176,7 @@ jobs:
 
           [raspberry_pi:vars]
           ansible_user=pi
+          ansible_ssh_pass=raspberry
           ansible_port=2222
           ansible_python_interpreter=/usr/bin/python3
           ansible_ssh_common_args=-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -36,7 +36,7 @@ env:
   ZIGBEE2MQTT_NETWORK_KEY: "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
 
 jobs:
-  test-ansible:
+  ansible-raspberry-pi-os-test:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     defaults:
@@ -71,10 +71,12 @@ jobs:
 
           # Mount root partition and enable SSH
           MOUNT_DIR=$(mktemp -d)
-          sudo mount -o loop,offset=$((ROOT_OFFSET * 512)) "${IMAGE_FILE}" "${MOUNT_DIR}"
+          ROOT_LOOP=$(sudo losetup --find --show --offset $((ROOT_OFFSET * 512)) "${IMAGE_FILE}")
+          sudo mount "${ROOT_LOOP}" "${MOUNT_DIR}"
 
           # Mount boot partition
-          sudo mount -o loop,offset=$((BOOT_OFFSET * 512)) "${IMAGE_FILE}" "${MOUNT_DIR}/boot/firmware"
+          BOOT_LOOP=$(sudo losetup --find --show --offset $((BOOT_OFFSET * 512)) "${IMAGE_FILE}")
+          sudo mount "${BOOT_LOOP}" "${MOUNT_DIR}/boot/firmware"
 
           # Enable SSH by creating the ssh file in boot partition
           sudo touch "${MOUNT_DIR}/boot/firmware/ssh"
@@ -91,7 +93,9 @@ jobs:
 
           # Unmount
           sudo umount "${MOUNT_DIR}/boot/firmware"
+          sudo losetup -d "${BOOT_LOOP}"
           sudo umount "${MOUNT_DIR}"
+          sudo losetup -d "${ROOT_LOOP}"
           rmdir "${MOUNT_DIR}"
 
           # Convert image to qcow2 for better performance

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   ansible-raspberry-pi-os-test:
-    runs-on: ubuntu-24.04-arm
+    runs-on: macos-latest
     timeout-minutes: 60
     defaults:
       run:
@@ -48,55 +48,92 @@ jobs:
 
       - name: Install QEMU and dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends cloud-image-utils qemu-efi-aarch64 qemu-system-arm sshpass xz-utils
+          brew install --quiet qemu e2fsprogs hudochenkov/sshpass/sshpass xz
 
       - name: Download latest Raspberry Pi OS image
         run: |
-          LATEST_DIR=$(curl -sL "${RASPIOS_BASE_URL}/" | grep -oP 'raspios_lite_arm64-\d{4}-\d{2}-\d{2}' | tail -1)
-          RASPIOS_IMAGE_URL="${RASPIOS_BASE_URL}/${LATEST_DIR}/$(curl -sL "${RASPIOS_BASE_URL}/${LATEST_DIR}/" | grep -oP '[^"]+\.img\.xz' | head -1)"
+          LATEST_DIR=$(curl -sL "${RASPIOS_BASE_URL}/" | grep -oE 'raspios_lite_arm64-[0-9]{4}-[0-9]{2}-[0-9]{2}' | tail -1)
+          RASPIOS_IMAGE_URL="${RASPIOS_BASE_URL}/${LATEST_DIR}/$(curl -sL "${RASPIOS_BASE_URL}/${LATEST_DIR}/" | grep -oE '[^"]+\.img\.xz' | head -1)"
           echo "Downloading: ${RASPIOS_IMAGE_URL}"
-          wget -q -O - "${RASPIOS_IMAGE_URL}" | xz -d > raspios.img
+          curl -sL "${RASPIOS_IMAGE_URL}" | xz -d > raspios.img
 
       - name: Prepare image for QEMU
         run: |
           IMAGE_FILE="raspios.img"
 
           # Resize image to give more space for packages
-          qemu-img resize "${IMAGE_FILE}" 8G
+          qemu-img resize -f raw "${IMAGE_FILE}" 8G
 
-          # Find partition offsets
-          BOOT_OFFSET=$(fdisk -l "${IMAGE_FILE}" | awk '/\.img1/{print $2}')
-          ROOT_OFFSET=$(fdisk -l "${IMAGE_FILE}" | awk '/\.img2/{print $2}')
+          # Parse MBR partition table to find partition offsets
+          # shellcheck disable=SC2034
+          PARTITIONS=$(python3 -c "
+          import struct
+          with open('${IMAGE_FILE}', 'rb') as f:
+              f.seek(446)
+              for i in range(4):
+                  entry = f.read(16)
+                  if len(entry) < 16:
+                      break
+                  ptype = entry[4]
+                  lba_start = struct.unpack('<I', entry[8:12])[0]
+                  lba_size = struct.unpack('<I', entry[12:16])[0]
+                  if lba_size > 0:
+                      print(f'{i+1} {ptype} {lba_start} {lba_size}')
+          ")
 
-          # Mount root partition and enable SSH
-          MOUNT_DIR=$(mktemp -d)
-          ROOT_LOOP=$(sudo losetup --find --show --offset $((ROOT_OFFSET * 512)) "${IMAGE_FILE}")
-          sudo mount "${ROOT_LOOP}" "${MOUNT_DIR}"
+          BOOT_START=$(echo "${PARTITIONS}" | awk 'NR==1{print $3}')
+          BOOT_SIZE=$(echo "${PARTITIONS}" | awk 'NR==1{print $4}')
+          ROOT_START=$(echo "${PARTITIONS}" | awk 'NR==2{print $3}')
 
-          # Mount boot partition
-          BOOT_LOOP=$(sudo losetup --find --show --offset $((BOOT_OFFSET * 512)) "${IMAGE_FILE}")
-          sudo mount "${BOOT_LOOP}" "${MOUNT_DIR}/boot/firmware"
+          BOOT_OFFSET_BYTES=$((BOOT_START * 512))
+          BOOT_SIZE_BYTES=$((BOOT_SIZE * 512))
+
+          echo "Boot partition: start=${BOOT_START}, size=${BOOT_SIZE} sectors"
+          echo "Root partition: start=${ROOT_START} sectors"
+
+          # Mount FAT32 boot partition using hdiutil
+          BOOT_DEV=$(hdiutil attach -nomount -imagekey diskimage-class=CRawDiskImage -section "${BOOT_OFFSET_BYTES},${BOOT_SIZE_BYTES}" "${IMAGE_FILE}" | awk '{print $1}')
+          BOOT_MOUNT=$(mktemp -d)
+          mount -t msdos "${BOOT_DEV}" "${BOOT_MOUNT}"
 
           # Enable SSH by creating the ssh file in boot partition
-          sudo touch "${MOUNT_DIR}/boot/firmware/ssh"
+          touch "${BOOT_MOUNT}/ssh"
 
-          # Enable password authentication in SSH
-          sudo sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' "${MOUNT_DIR}/etc/ssh/sshd_config"
+          # Create userconf.txt for pi user with password 'raspberry'
+          ENCRYPTED_PASS=$(python3 -c "import crypt; print(crypt.crypt('raspberry', crypt.mksalt(crypt.METHOD_SHA256)))")
+          echo "pi:${ENCRYPTED_PASS}" > "${BOOT_MOUNT}/userconf.txt"
 
-          # Ensure pi user exists with password 'raspberry'
-          # The default Raspberry Pi OS image should already have this
+          # Create firstrun.sh to enable password authentication
+          cat > "${BOOT_MOUNT}/firstrun.sh" <<'FIRSTRUN'
+          #!/bin/bash
+          set -e
+          sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+          systemctl restart ssh
+          rm -f /boot/firmware/firstrun.sh
+          FIRSTRUN
+          chmod +x "${BOOT_MOUNT}/firstrun.sh"
 
-          # Copy kernel and initrd for QEMU direct kernel boot
-          cp "${MOUNT_DIR}/boot/firmware/kernel8.img" .
-          cp "${MOUNT_DIR}/boot/firmware/initramfs8" . || true
+          # Add firstrun.sh to cmdline.txt if not already present
+          if ! grep -q "firstrun.sh" "${BOOT_MOUNT}/cmdline.txt" 2>/dev/null; then
+            CMDLINE=$(cat "${BOOT_MOUNT}/cmdline.txt")
+            echo "${CMDLINE} systemd.run=/boot/firmware/firstrun.sh systemd.run_success_action=none systemd.unit=kernel-command-line.target" > "${BOOT_MOUNT}/cmdline.txt"
+          fi
 
-          # Unmount
-          sudo umount "${MOUNT_DIR}/boot/firmware"
-          sudo losetup -d "${BOOT_LOOP}"
-          sudo umount "${MOUNT_DIR}"
-          sudo losetup -d "${ROOT_LOOP}"
-          rmdir "${MOUNT_DIR}"
+          # Unmount boot partition
+          umount "${BOOT_MOUNT}"
+          hdiutil detach "${BOOT_DEV}"
+          rmdir "${BOOT_MOUNT}"
+
+          # Modify sshd_config on root partition (ext4) using debugfs
+          E2FSPROGS_PREFIX="$(brew --prefix e2fsprogs)"
+          SSHD_CONFIG=$("${E2FSPROGS_PREFIX}/sbin/debugfs" -R "cat etc/ssh/sshd_config" -f /dev/stdin "${IMAGE_FILE}" -b 512 -s "${ROOT_START}" 2>/dev/null || true)
+          if [ -n "${SSHD_CONFIG}" ]; then
+            MODIFIED_CONFIG="${SSHD_CONFIG//\#*PasswordAuthentication*/PasswordAuthentication yes}"
+            TMPFILE=$(mktemp)
+            echo "${MODIFIED_CONFIG}" > "${TMPFILE}"
+            echo "write ${TMPFILE} etc/ssh/sshd_config" | "${E2FSPROGS_PREFIX}/sbin/debugfs" -w "${IMAGE_FILE}" -b 512 -s "${ROOT_START}" 2>/dev/null || true
+            rm -f "${TMPFILE}"
+          fi
 
           # Convert image to qcow2 for better performance
           qemu-img convert -f raw -O qcow2 "${IMAGE_FILE}" raspios.qcow2
@@ -104,21 +141,15 @@ jobs:
 
       - name: Boot Raspberry Pi OS in QEMU
         run: |
+          UEFI_FW="$(brew --prefix qemu)/share/qemu/edk2-aarch64-code.fd"
 
-          # Copy UEFI firmware
-          cp /usr/share/AAVMF/AAVMF_CODE.fd flash0.img
-          cp /usr/share/AAVMF/AAVMF_VARS.fd flash1.img
+          # Create writable copies of UEFI firmware
+          cp "${UEFI_FW}" flash0.img
+          dd if=/dev/zero of=flash1.img bs=1m count=64
 
-          # Start QEMU in background (use KVM if available, otherwise TCG)
-          if [ -e /dev/kvm ]; then
-            ACCEL_OPTS="-accel kvm -cpu host"
-          else
-            ACCEL_OPTS="-accel tcg -cpu cortex-a72"
-          fi
-
-          # shellcheck disable=SC2086
+          # Start QEMU in background with HVF hardware virtualization
           qemu-system-aarch64 \
-            -machine virt,gic-version=max ${ACCEL_OPTS} -m 2048 -smp 2 \
+            -machine virt,highmem=on -accel hvf -cpu host -m 2048 -smp 2 \
             -drive if=pflash,format=raw,file=flash0.img,readonly=on \
             -drive if=pflash,format=raw,file=flash1.img \
             -drive if=virtio,file=raspios.qcow2,format=qcow2 \
@@ -154,7 +185,7 @@ jobs:
 
       - name: Install Ansible
         run: |
-          sudo apt-get install -y --no-install-recommends ansible sshpass
+          pip3 install --break-system-packages ansible
 
       - name: Create test inventory
         run: |

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -74,7 +74,7 @@ jobs:
           sudo mount -o loop,offset=$((ROOT_OFFSET * 512)) "${IMAGE_FILE}" "${MOUNT_DIR}"
 
           # Mount boot partition
-          sudo mount -o loop,offset=$((BOOT_OFFSET * 512)) "${MOUNT_DIR}/boot/firmware"
+          sudo mount -o loop,offset=$((BOOT_OFFSET * 512)) "${IMAGE_FILE}" "${MOUNT_DIR}/boot/firmware"
 
           # Enable SSH by creating the ssh file in boot partition
           sudo touch "${MOUNT_DIR}/boot/firmware/ssh"

--- a/.github/workflows/ansible-raspberry-pi-os-test.yml
+++ b/.github/workflows/ansible-raspberry-pi-os-test.yml
@@ -147,7 +147,11 @@ jobs:
           sshpass -p raspberry ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 pi@127.0.0.1 bash -s <<'REMOTE_SCRIPT'
           sudo mkdir -p /boot/firmware
           # Install packages that the playbook expects (present on RPi OS but not Debian cloud)
-          sudo apt-get update -qq && sudo apt-get install -y -qq cron logrotate rsync
+          sudo apt-get update -qq && sudo apt-get install -y -qq cron gnupg logrotate rsync
+          # Install Docker GPG key and repo (the playbook's get_url downloads armored key which needs dearmoring)
+          curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker.gpg
+          echo "deb [signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" | sudo tee /etc/apt/sources.list.d/docker.list
+          sudo apt-get update -qq && sudo apt-get install -y -qq docker-ce docker-ce-cli containerd.io
           # Create restore logs to skip backup restore tasks (backup server is unreachable in CI)
           sudo touch /var/log/restore-prometheus.log /var/log/restore-hass.log
           # Pre-populate config.txt with the content the playbook would write (blockinfile)

--- a/ansible/tasks/apps.yml
+++ b/ansible/tasks/apps.yml
@@ -216,7 +216,7 @@
 - name: Add Mosquitto apt signing keys
   ansible.builtin.get_url:
     url: https://repo.mosquitto.org/debian/mosquitto-repo.gpg
-    dest: /etc/apt/trusted.gpg.d/mosquitto-repo.asc
+    dest: /etc/apt/trusted.gpg.d/mosquitto-repo.gpg
     mode: u=rw,g=r,o=r
 
 - name: Add Mosquitto apt signing keys
@@ -225,7 +225,7 @@
     uris: https://repo.mosquitto.org/debian
     suites: "{{ ansible_facts.distribution_release }}"
     components: [main]
-    signed_by: /etc/apt/trusted.gpg.d/mosquitto-repo.asc
+    signed_by: /etc/apt/trusted.gpg.d/mosquitto-repo.gpg
 
 - name: Install mosquitto
   ansible.builtin.apt:


### PR DESCRIPTION
## Summary

- Fix the boot partition `mount` command in the QEMU image preparation step that was missing the `"${IMAGE_FILE}"` source argument, causing `can't find in /etc/fstab` error