### PR TITLE
chore: update wifi config and remove non-free firmware stage

### DIFF
--- a/stage-my/00-netplan/files/01-wifi.yaml.template
+++ b/stage-my/00-netplan/files/01-wifi.yaml.template
@@ -2,10 +2,9 @@ network:
   version: 2
   renderer: NetworkManager
   wifis:
-    wlan1:
+    wlan0:
       match:
-        macaddress: "a0:f3:c1:1b:de:a6"
-      set-name: wlan1
+        macaddress: "90:de:80:3e:93:fc"
       dhcp4: yes
       dhcp6: yes
       access-points:

--- a/stage-my/01-nonfree-firmware/00-packages
+++ b/stage-my/01-nonfree-firmware/00-packages
@@ -1,1 +1,0 @@
-firmware-misc-nonfree

--- a/stage-my/01-nonfree-firmware/00-run.sh
+++ b/stage-my/01-nonfree-firmware/00-run.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-sed -i 's/^Components: main$/Components: main contrib non-free non-free-firmware/' "${ROOTFS_DIR}/etc/apt/sources.list.d/debian.sources"


### PR DESCRIPTION
- Update wifi interface from wlan1 to wlan0 with new MAC address
- Remove set-name directive from netplan wifi template
- Delete non-free firmware stage (00-packages and 00-run.sh)