### PR TITLE
feat: enable home assistant, homepage and firewalld

### DIFF
--- a/ansible/files/etc/alloy/config.alloy.j2
+++ b/ansible/files/etc/alloy/config.alloy.j2
@@ -362,7 +362,10 @@ discovery.relabel "integrations_blackbox" {
 // Configure a prometheus.scrape component to collect blackbox metrics.
 prometheus.scrape "integrations_blackbox" {
   targets    = discovery.relabel.integrations_blackbox.output
-  forward_to = [prometheus.remote_write.prometheus_metrics_service.receiver]
+  forward_to = [
+    prometheus.remote_write.grafana_cloud_metrics_service.receiver,
+    prometheus.remote_write.prometheus_metrics_service.receiver,
+  ]
   job_name   = "integrations/blackbox"
 }
 
@@ -374,7 +377,10 @@ prometheus.scrape "integrations_blackbox" {
 prometheus.scrape "docker" {
   targets    = [{"__address__" = "localhost:9323"}]
   job_name   = "docker"
-  forward_to = [prometheus.remote_write.prometheus_metrics_service.receiver]
+  forward_to = [
+    prometheus.remote_write.grafana_cloud_metrics_service.receiver,
+    prometheus.remote_write.prometheus_metrics_service.receiver,
+  ]
 }
 
 // #########################################################
@@ -416,25 +422,57 @@ prometheus.relabel "integrations_node_exporter_openwrt" {
 prometheus.scrape "prometheus" {
   targets    = [{"__address__" = "localhost:9090"}]
   job_name   = "prometheus"
-  forward_to = [prometheus.remote_write.prometheus_metrics_service.receiver]
+  forward_to = [
+    prometheus.remote_write.grafana_cloud_metrics_service.receiver,
+    prometheus.remote_write.prometheus_metrics_service.receiver,
+  ]
 }
 
 // Grafana
 prometheus.scrape "grafana" {
   targets    = [{"__address__" = "localhost:3001"}]
   job_name   = "grafana"
-  forward_to = [prometheus.remote_write.prometheus_metrics_service.receiver]
+  forward_to = [
+    prometheus.remote_write.grafana_cloud_metrics_service.receiver,
+    prometheus.remote_write.prometheus_metrics_service.receiver,
+  ]
 }
 
-// ESPHome
-prometheus.scrape "esphome" {
+// Home Assistant
+prometheus.scrape "hass" {
+  targets         = [{"__address__" = "127.0.0.1:8123"}]
+  job_name        = "hass"
+  metrics_path    = "/api/prometheus"
+  scrape_interval = "60s"
+  bearer_token    = "{{ prometheus_hass_bearer_token }}"
+  forward_to      = [
+    prometheus.remote_write.grafana_cloud_metrics_service.receiver,
+    prometheus.remote_write.prometheus_metrics_service.receiver,
+  ]
+}
+
+// MSR-2 - https://apolloautomation.com/products/msr-2
+prometheus.scrape "msr_2" {
   targets    = [{"__address__" = "192.168.1.4:80"}]
   basic_auth {
     username = "{{ esphome_web_server_username }}"
     password = "{{ esphome_web_server_password }}"
   }
-  job_name   = "esphome"
-  forward_to = [prometheus.remote_write.prometheus_metrics_service.receiver]
+  job_name   = "msr-2"
+  forward_to = [
+    prometheus.remote_write.grafana_cloud_metrics_service.receiver,
+    prometheus.remote_write.prometheus_metrics_service.receiver,
+  ]
+}
+
+// Laptop
+prometheus.scrape "peru_laptop" {
+  targets    = [{"__address__" = "192.168.1.5:9100"}]
+  job_name   = "peru-laptop"
+  forward_to = [
+    prometheus.remote_write.grafana_cloud_metrics_service.receiver,
+    prometheus.remote_write.prometheus_metrics_service.receiver,
+  ]
 }
 
 // #########################################################

--- a/ansible/files/etc/mosquitto/password_file.j2
+++ b/ansible/files/etc/mosquitto/password_file.j2
@@ -1,4 +1,0 @@
-{% for item in mqtt_clients|dict2items %}
-# {{ item.key }}
-{{ item.value.user }}:{{ '%s' | format(item.value.password) | mosquitto_passwd }}
-{% endfor %}

--- a/ansible/files/home/kodi/.config/wireplumber/wireplumber.conf.d/50-audio.conf.j2
+++ b/ansible/files/home/kodi/.config/wireplumber/wireplumber.conf.d/50-audio.conf.j2
@@ -16,7 +16,7 @@ monitor.bluez.rules = [
 
 monitor.alsa.rules = [
   {
-    matches = [ { node.name = "alsa_output.platform-fef00700.hdmi.hdmi-stereo" } ]
+    matches = [ { node.name = "alsa_output.platform-fef05700.hdmi.hdmi-stereo" } ]
     actions = {
       update-props = {
         priority.driver = 1005

--- a/ansible/files/var/lib/homepage/config/services.yaml.j2
+++ b/ansible/files/var/lib/homepage/config/services.yaml.j2
@@ -42,14 +42,14 @@
 
     - Grafana:
         description: The open and composable observability and data visualization platform. Visualize metrics, logs, and traces from multiple sources like Prometheus, Loki, Elasticsearch, InfluxDB, Postgres and many more.
-        href: {{ grafana_url }}
+        href: {{ grafana_ini.server.root_url }}
         icon: grafana.svg
         siteMonitor: http://127.0.0.1:3001/healthz
         widget:
           type: grafana
           url: http://127.0.0.1:3001
-          username: {{ grafana_security.admin_user }}
-          password: {{ grafana_security.admin_password }}
+          username: admin
+          password: {{ grafana_ini.security.admin_password }}
 
     - Home Assistant:
         container: home-assistant

--- a/ansible/files/var/lib/homepage/config/services.yaml.j2
+++ b/ansible/files/var/lib/homepage/config/services.yaml.j2
@@ -124,7 +124,7 @@
         description: Zigbee 🐝 to MQTT bridge 🌉, get rid of your proprietary Zigbee bridges 🔨
         href: https://zigbee2mqtt-rpi.xvx.cz/
         icon: zigbee2mqtt.svg
-        siteMonitor: http://127.0.0.1:8082
+        siteMonitor: http://127.0.0.1:8090
 
     - cAdvisor:
         description: Analyzes resource usage and performance characteristics of running containers.

--- a/ansible/files/var/lib/zigbee2mqtt/configuration.yaml.j2
+++ b/ansible/files/var/lib/zigbee2mqtt/configuration.yaml.j2
@@ -1,10 +1,17 @@
-version: 4
+version: 5
 advanced:
   last_seen: ISO_8601
   log_output:
     - console
+  # 128-bit AES encryption key used to encrypt all Zigbee network traffic.
+  # Devices must share this key to communicate. Changing it forces all devices to re-join.
   network_key: {{ zigbee2mqtt_network_key }}
+  # 16-bit Personal Area Network ID (0x0000-0x3FFF) that distinguishes this
+  # Zigbee network from neighboring ones. Similar to a Wi-Fi SSID but numeric.
   pan_id: {{ zigbee2mqtt_pan_id }}
+  # 64-bit Extended PAN ID providing a globally unique network identity.
+  # Used during network formation and device joining to avoid collisions
+  # when multiple networks share the same pan_id.
   ext_pan_id: {{ zigbee2mqtt_ext_pan_id }}
   transmit_power: 20
 devices:

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -27,23 +27,10 @@ esphome_api_encryption_key: "{{ lookup('env', 'ESPHOME_API_ENCRYPTION_KEY') }}"
 esphome_ota_password: "{{ lookup('env', 'ESPHOME_OTA_PASSWORD') }}"
 esphome_web_server_password: "{{ lookup('env', 'ESPHOME_WEB_SERVER_PASSWORD') }}"
 esphome_web_server_username: admin
-firewall_additional_rules:
-  - "iptables -A INPUT -m pkttype --pkt-type multicast -j ACCEPT"
-  - "iptables -t nat -A POSTROUTING -o {{ ansible_facts.default_ipv4.interface }} -j MASQUERADE"
-firewall_allowed_tcp_ports: "{{ fw_allowed_tcp_ports }}"
-firewall_allowed_udp_ports: "{{ fw_allowed_udp_ports }}"
-firewall_forwarded_tcp_ports: "{{ fw_forwarded_tcp_ports }}"
-firewall_log_dropped_packets: false
-fw_allowed_tcp_ports:
-  - 22 # SSH
-  - 22222 # SSH
-  - 1883 # MQTT
-fw_allowed_udp_ports:
-  - 1883 # MQTT
-  - 5353 # mDNS - avahi-daemon
-fw_forwarded_tcp_ports:
-  - src: 22222
-    dest: 22
+firewalld_allowed_services:
+  - ssh
+  - mdns
+  - mqtt
 grafana_dashboards:
   # 1617-systemd-service-dashboard
   - dashboard_id: 1617
@@ -109,16 +96,16 @@ grafana_ini:
     password: "{{ msmtp_auth_password }}"
 # renovate: datasource=github-tags depName=grafana/grafana
 grafana_version: 13.0.1
-# hacs_github_token: "{{ lookup('env', 'HACS_GITHUB_TOKEN') }}"
-# hass_auth_password_hash: "{{ lookup('env', 'HASS_AUTH_PASSWORD_HASH') }}"
-# hass_auth_refresh_token_prometheus: "{{ lookup('env', 'HASS_AUTH_REFRESH_TOKEN_PROMETHEUS') }}"
-# hass_auth_refresh_token_prometheus_jwt_key: "{{ lookup('env', 'HASS_AUTH_REFRESH_TOKEN_PROMETHEUS_JWT_KEY') }}"
-# hass_auth_refresh_token_system: "{{ lookup('env', 'HASS_AUTH_REFRESH_TOKEN_SYSTEM') }}"
-# hass_auth_refresh_token_system_jwt_key: "{{ lookup('env', 'HASS_AUTH_REFRESH_TOKEN_SYSTEM_JWT_KEY') }}"
-# hass_config_directory: /var/lib/hass_config
-# hass_totp_secret: "{{ lookup('env', 'HASS_TOTP_SECRET') }}"
+hacs_github_token: "{{ lookup('env', 'HACS_GITHUB_TOKEN') }}"
+hass_auth_password_hash: "{{ lookup('env', 'HASS_AUTH_PASSWORD_HASH') }}"
+hass_auth_refresh_token_prometheus: "{{ lookup('env', 'HASS_AUTH_REFRESH_TOKEN_PROMETHEUS') }}"
+hass_auth_refresh_token_prometheus_jwt_key: "{{ lookup('env', 'HASS_AUTH_REFRESH_TOKEN_PROMETHEUS_JWT_KEY') }}"
+hass_auth_refresh_token_system: "{{ lookup('env', 'HASS_AUTH_REFRESH_TOKEN_SYSTEM') }}"
+hass_auth_refresh_token_system_jwt_key: "{{ lookup('env', 'HASS_AUTH_REFRESH_TOKEN_SYSTEM_JWT_KEY') }}"
+hass_config_directory: /var/lib/hass_config
+hass_totp_secret: "{{ lookup('env', 'HASS_TOTP_SECRET') }}"
 hass_url: https://hass-rpi.xvx.cz
-# hass_user_password: "{{ lookup('env', 'HASS_USER_PASSWORD') }}"
+hass_user_password: "{{ lookup('env', 'HASS_USER_PASSWORD') }}"
 kernel_modules:
   - nf_conntrack
 kodi_guisettings_services_webserverpassword: "{{ lookup('env', 'KODI_GUISETTINGS_SERVICES_WEBSERVERPASSWORD') }}"
@@ -145,11 +132,6 @@ prometheus_version: 3.11.3
 prometheus_web_external_url: https://prometheus-rpi.xvx.cz
 prometheus_web_listen_address: 127.0.0.1:9090
 rpi_disable_boot_services:
-  - cloud-config.service
-  - cloud-final.service
-  - cloud-init-local.service
-  - cloud-init-main.service
-  - cloud-init-network.service
   - console-setup
   - dnsmasq
   - keyboard-setup

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -19,6 +19,7 @@
         dest: /etc/sudoers.d/pi
         mode: u=r,g=r,o=
         validate: "visudo -cf %s"
+        backup: true
 
     - name: Change pi and root user password
       ansible.builtin.user:
@@ -37,8 +38,6 @@
       until: result is succeeded
 
   roles:
-    - role: geerlingguy.firewall
-      tags: [firewall]
     - role: grafana.grafana.alloy
       tags: [alloy]
       vars:
@@ -54,6 +53,7 @@
       tags: [prometheus]
       vars:
         prometheus_storage_retention_size: 5GB
+        prometheus_scrape_configs: []
         prometheus_config_flags_extra:
           web.enable-admin-api:
           web.enable-remote-write-receiver:

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -12,7 +12,3 @@ collections:
   - name: prometheus.prometheus
     version: 0.29.2
   # keep-sorted end
-
-roles:
-  - name: geerlingguy.firewall
-    version: 2.7.0

--- a/ansible/tasks/apps.yml
+++ b/ansible/tasks/apps.yml
@@ -187,7 +187,6 @@
     group: mosquitto
     backup: true
   no_log: true
-  notify: Restart mosquitto
   changed_when: false
 
 #################################################

--- a/ansible/tasks/apps.yml
+++ b/ansible/tasks/apps.yml
@@ -174,6 +174,9 @@
     backup: true
   notify: Restart mosquitto
 
+# NOTE: mosquitto_passwd filter uses a random salt, so this task reports
+# "changed" on every run and restarts Mosquitto. This is intentional to
+# ensure credential rotations are always picked up.
 - name: Create '/etc/mosquitto/password_file' file
   ansible.builtin.copy:
     dest: /etc/mosquitto/password_file
@@ -187,7 +190,7 @@
     group: mosquitto
     backup: true
   no_log: true
-  changed_when: false
+  notify: Restart mosquitto
 
 #################################################
 # Zigbee2MQTT (zigbee2mqtt-rpi.xvx.cz)

--- a/ansible/tasks/apps.yml
+++ b/ansible/tasks/apps.yml
@@ -8,6 +8,7 @@
     dest: /root/.ssh/id_ed25519-backup_raspi.xvx.cz.pub
     mode: u=rw,g=,o=
     owner: root
+    backup: true
   no_log: true
 
 - name: Install ssh private key id_ed25519-backup_raspi.xvx.cz
@@ -16,18 +17,19 @@
     dest: /root/.ssh/id_ed25519-backup_raspi.xvx.cz
     mode: u=rw,g=,o=
     owner: root
+    backup: true
   no_log: true
 
-- name: Creates Backup Prometheus file /etc/cron.d/backup-prometheus
-  ansible.builtin.cron:
-    name: Backup Prometheus
-    weekday: "*"
-    minute: "0"
-    hour: "3"
-    user: root
-    job: PROMETHEUS_SNAPSHOT_DIR=$(curl -s -X POST http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot | jq -r '.data.name') && rsync --archive --verbose --delete --log-file=/tmp/backup-prometheus.log -e 'ssh -i /root/.ssh/id_ed25519-backup_raspi.xvx.cz -o StrictHostKeyChecking=no' /var/lib/prometheus/snapshots/${PROMETHEUS_SNAPSHOT_DIR}/ {{ backup_user }}@{{ backup_server }}:{{ backup_directory }}/prometheus/ > /dev/null && rm -rf /var/lib/prometheus/snapshots
-    cron_file: backup-prometheus
-  tags: [prometheus]
+# - name: Creates Backup Prometheus file /etc/cron.d/backup-prometheus
+#   ansible.builtin.cron:
+#     name: Backup Prometheus
+#     weekday: "*"
+#     minute: "0"
+#     hour: "3"
+#     user: root
+#     job: PROMETHEUS_SNAPSHOT_DIR=$(curl -s -X POST http://127.0.0.1:9090/api/v1/admin/tsdb/snapshot | jq -r '.data.name') && rsync --archive --verbose --delete --log-file=/tmp/backup-prometheus.log -e 'ssh -i /root/.ssh/id_ed25519-backup_raspi.xvx.cz -o StrictHostKeyChecking=no' /var/lib/prometheus/snapshots/${PROMETHEUS_SNAPSHOT_DIR}/ {{ backup_user }}@{{ backup_server }}:{{ backup_directory }}/prometheus/ > /dev/null && rm -rf /var/lib/prometheus/snapshots
+#     cron_file: backup-prometheus
+#   tags: [prometheus]
 
 # - name: Creates Backup HASS file /etc/cron.d/backup-hass
 #   ansible.builtin.cron:
@@ -39,46 +41,46 @@
 #     job: HASS_BACKUP_FILE=$(ls -t {{ hass_config_directory }}/backups/*.tar | head -1) && rsync --archive --verbose --delete --log-file=/tmp/backup-hass.log --rsh='ssh -i /root/.ssh/id_ed25519-backup_raspi.xvx.cz -o StrictHostKeyChecking=no' "${HASS_BACKUP_FILE}" "{{ backup_user }}@{{ backup_server }}:{{ backup_directory }}/hass_config/hass_config_latest_backup.tar" > /dev/null && rm {{ hass_config_directory }}/backups/*.tar
 #     cron_file: backup-hass
 
-- name: Check if /var/log/restore-prometheus.log exists
-  ansible.builtin.stat:
-    path: /var/log/restore-prometheus.log
-  register: prometheus_restore_log
-  tags: [prometheus]
+# - name: Check if /var/log/restore-prometheus.log exists
+#   ansible.builtin.stat:
+#     path: /var/log/restore-prometheus.log
+#   register: prometheus_restore_log
+#   tags: [prometheus]
 
-- name: Restore Prometheus from backup
-  when: not prometheus_restore_log.stat.exists
-  tags: [prometheus]
-  block:
-    - name: Stop Prometheus
-      ansible.builtin.systemd_service:
-        name: prometheus
-        state: stopped
+# - name: Restore Prometheus from backup
+#   when: not prometheus_restore_log.stat.exists
+#   tags: [prometheus]
+#   block:
+#     - name: Stop Prometheus
+#       ansible.builtin.systemd_service:
+#         name: prometheus
+#         state: stopped
 
-    - name: Restore Prometheus from backup # noqa: command-instead-of-module
-      ansible.builtin.shell: |
-        rsync --archive --verbose --chown=prometheus:prometheus --delete --log-file=/var/log/restore-prometheus.log --rsh='ssh -i /root/.ssh/id_ed25519-backup_raspi.xvx.cz -o StrictHostKeyChecking=no' {{ backup_user }}@{{ backup_server }}:{{ backup_directory }}/prometheus/ /var/lib/prometheus/
-      changed_when: true
+#     - name: Restore Prometheus from backup # noqa: command-instead-of-module
+#       ansible.builtin.shell: |
+#         rsync --archive --verbose --chown=prometheus:prometheus --delete --log-file=/var/log/restore-prometheus.log --rsh='ssh -i /root/.ssh/id_ed25519-backup_raspi.xvx.cz -o StrictHostKeyChecking=no' {{ backup_user }}@{{ backup_server }}:{{ backup_directory }}/prometheus/ /var/lib/prometheus/
+#       changed_when: true
 
-    - name: Start Prometheus
-      ansible.builtin.systemd_service:
-        name: prometheus
-        state: started
-  rescue:
-    - name: Print when errors
-      ansible.builtin.fail:
-        msg: Restore from backup failed
+#     - name: Start Prometheus
+#       ansible.builtin.systemd_service:
+#         name: prometheus
+#         state: started
+#   rescue:
+#     - name: Print when errors
+#       ansible.builtin.fail:
+#         msg: Restore from backup failed
 
-- name: Check if /var/log/restore-hass.log exists
-  ansible.builtin.stat:
-    path: /var/log/restore-hass.log
-  register: hass_restore_log
+# - name: Check if /var/log/restore-hass.log exists
+#   ansible.builtin.stat:
+#     path: /var/log/restore-hass.log
+#   register: hass_restore_log
 
-- name: Create HASS directory (/var/lib/hass_config)
-  when: not hass_restore_log.stat.exists
-  ansible.builtin.file:
-    path: /var/lib/hass_config/blueprints/automation/homeassistant
-    state: directory
-    recurse: true
+# - name: Create HASS directory (/var/lib/hass_config)
+#   when: not hass_restore_log.stat.exists
+#   ansible.builtin.file:
+#     path: /var/lib/hass_config/blueprints/automation/homeassistant
+#     state: directory
+#     recurse: true
 
 # - name: Restore HASS from backup # noqa: command-instead-of-module
 #   when: not hass_restore_log.stat.exists
@@ -88,87 +90,6 @@
 #   args:
 #     executable: /bin/bash
 #   changed_when: true
-
-#################################################
-# Docker
-#################################################
-
-- name: Add Docker apt signing keys
-  ansible.builtin.get_url:
-    url: https://download.docker.com/linux/debian/gpg
-    dest: /usr/share/keyrings/docker.gpg
-    mode: u=rw,g=r,o=r
-
-- name: Add Docker repository
-  ansible.builtin.deb822_repository:
-    name: docker
-    uris: https://download.docker.com/linux/debian
-    suites: "{{ ansible_facts.distribution_release }}"
-    components: stable
-    signed_by: /usr/share/keyrings/docker.gpg
-
-- name: Create Docker daemon configuration directory
-  ansible.builtin.file:
-    path: /etc/docker
-    state: directory
-    mode: u=rwx,g=rx,o=rx
-
-- name: Configure Docker daemon
-  ansible.builtin.copy:
-    dest: /etc/docker/daemon.json
-    content: |
-      {{ docker_config | to_nice_json }}
-    mode: u=rw,g=r,o=r
-  notify: Restart docker
-
-- name: Install docker
-  ansible.builtin.apt:
-    name:
-      - docker-ce
-      - docker-ce-cli
-      - containerd.io
-    update_cache: true
-    install_recommends: false
-  register: result
-  until: result is succeeded
-
-- name: Start and enable Docker service
-  ansible.builtin.systemd_service:
-    name: docker
-    state: started
-    enabled: true
-    daemon_reload: true
-
-- name: Add pi and alloy users to the docker group
-  ansible.builtin.user:
-    name: "{{ item }}"
-    groups: docker
-    append: true
-  loop:
-    - pi
-    - alloy
-
-#################################################
-# Prometheus
-#################################################
-
-# - name: Create HASS scape config for Prometheus (/etc/prometheus/scrape_configs/hass.yml)
-#   ansible.builtin.copy:
-#     dest: /etc/prometheus/scrape_configs/hass.yml
-#     content: |
-#       scrape_configs:
-#         - job_name: hass
-#           scrape_interval: 60s
-#           metrics_path: /api/prometheus
-#           bearer_token: "{{ prometheus_hass_bearer_token }}"
-#           static_configs:
-#             - targets:
-#                 - 127.0.0.1:8123
-#     mode: u=rw,g=,o=
-#     owner: prometheus
-#     group: prometheus
-#   no_log: true
-#   notify: Restart prometheus
 
 #################################################
 # Cloudflared
@@ -201,6 +122,7 @@
     src: files/etc/systemd/system/cloudflared.service
     dest: /etc/systemd/system/cloudflared.service
     mode: u=rw,g=r,o=r
+    backup: true
   notify: Reload systemd
 
 - name: Configure cloudflared
@@ -209,6 +131,7 @@
     content: |
       CLOUDFLARED_TOKEN={{ cloudflared_tunnel_token }}
     mode: u=rw,g=,o=
+    backup: true
   no_log: true
   notify: Restart cloudflared
 
@@ -248,21 +171,27 @@
     mode: u=rw,g=,o=
     owner: mosquitto
     group: mosquitto
+    backup: true
   notify: Restart mosquitto
 
 - name: Create '/etc/mosquitto/password_file' file
-  ansible.builtin.template:
+  ansible.builtin.copy:
     dest: /etc/mosquitto/password_file
-    src: files/etc/mosquitto/password_file.j2
+    content: |
+      {% for item in mqtt_clients | dict2items %}
+      # {{ item.key }}
+      {{ item.value.user }}:{{ '%s' | format(item.value.password) | mosquitto_passwd }}
+      {% endfor %}
     mode: u=rw,g=,o=
     owner: mosquitto
     group: mosquitto
+    backup: true
   no_log: true
   notify: Restart mosquitto
   changed_when: false
 
 #################################################
-# Zigbee2MQTT
+# Zigbee2MQTT (zigbee2mqtt-rpi.xvx.cz)
 #################################################
 
 - name: Create Zigbee2MQTT directory (/var/lib/zigbee2mqtt)
@@ -276,6 +205,7 @@
     dest: /var/lib/zigbee2mqtt/configuration.yaml
     src: files/var/lib/zigbee2mqtt/configuration.yaml.j2
     mode: u=rw,g=r,o=r
+    backup: true
   no_log: true
   notify: Restart zigbee2mqtt
 
@@ -284,12 +214,14 @@
     src: files/var/lib/zigbee2mqtt/database.db
     dest: /var/lib/zigbee2mqtt/database.db
     mode: u=rw,g=r,o=r
+    force: false
+    backup: true
   notify: Restart zigbee2mqtt
 
 - name: Zigbee2MQTT container
   community.docker.docker_container:
     name: zigbee2mqtt
-    image: docker.io/koenkk/zigbee2mqtt:2.10.0@sha256:e9279e580bb25c512cf6e54c36e215a5cbd2881d1f201cf2a8213a97b14be3d2
+    image: ghcr.io/koenkk/zigbee2mqtt:2.10.1@sha256:67c26dcf8346aced02fe1380a6afd1b57268bcef10faae3f6057c13d5d3dfa80
     comparisons:
       image: strict
       labels: allow_more_present
@@ -298,7 +230,7 @@
       - /run/dbus:/run/dbus:ro
       - /var/lib/zigbee2mqtt:/app/data
     ports:
-      - 8082:8080
+      - 8090:8080
     env:
       TZ: "{{ timezone }}"
     labels:
@@ -311,7 +243,7 @@
   notify: Restart zigbee2mqtt
 
 #################################################
-# ESPHome
+# ESPHome (esphome-rpi.xvx.cz)
 #################################################
 
 - name: Create ESPHome directory (/var/lib/esphome/config)
@@ -320,14 +252,12 @@
     state: directory
     recurse: true
 
-- name: Configure ESPHome (/var/lib/esphome/config/apollo-msr-2.yaml)
+- name: Configure ESPHome (/var/lib/esphome/config/apollo-msr-2-f585f4.yaml)
   ansible.builtin.template:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
+    src: files/var/lib/esphome/config/apollo-msr-2-f585f4.yaml.j2
+    dest: /var/lib/esphome/config/apollo-msr-2-f585f4.yaml
     mode: u=rw,g=r,o=r
-  loop:
-    - dest: /var/lib/esphome/config/apollo-msr-2-f585f4.yaml
-      src: files/var/lib/esphome/config/apollo-msr-2-f585f4.yaml.j2
+    backup: true
   notify: Restart esphome
 
 - name: Create secret file for ESPHome
@@ -335,6 +265,7 @@
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
     mode: u=rw,g=,o=
+    backup: true
   loop:
     - dest: /var/lib/esphome/config/secrets.yaml
       src: files/var/lib/esphome/config/secrets.yaml.j2
@@ -344,7 +275,7 @@
 - name: ESPHome container
   community.docker.docker_container:
     name: esphome
-    image: ghcr.io/esphome/esphome:2026.4.2@sha256:a2784bc539dcf7529241bfe4425d645f1076031f9bf9ce07f5d59d1c45e9ff22
+    image: ghcr.io/esphome/esphome:2026.4.5@sha256:7419641c7fd8e37d6362f71c458bb17570f1f471cfea3b022b30dfd8117a2361
     comparisons:
       image: strict
       labels: allow_more_present
@@ -370,6 +301,13 @@
 # Home Assistant
 #################################################
 
+- name: Create Home Assistant directory ({{ hass_config_directory }})
+  ansible.builtin.file:
+    path: "{{ hass_config_directory }}/.storage"
+    state: directory
+    recurse: true
+
+# NOT NEEDED ANY MORE - FILES ARE ALREADY IN PLACE
 # - name: Download automation/blueprints files
 #   ansible.builtin.get_url:
 #     url: "{{ item }}"
@@ -380,79 +318,84 @@
 #     - https://raw.githubusercontent.com/home-assistant/core/b07682e43cd2604ef387bae79bcae555b15516b8/homeassistant/components/automation/blueprints/notify_leaving_zone.yaml
 #   notify: Restart hass
 
-# - name: Copy config files for Home Assistant to {{ hass_config_directory }}/
-#   ansible.builtin.copy:
-#     src: "{{ item }}"
-#     dest: "{{ hass_config_directory }}/"
-#     mode: u=rw,g=r,o=r
-#   loop:
-#     - files/{{ hass_config_directory }}/.storage/core.device_registry
-#     - files/{{ hass_config_directory }}/lovelace
-#     - files/{{ hass_config_directory }}/known_devices.yaml
-#     - files/{{ hass_config_directory }}/automations.yaml
-#   notify: Restart hass
+- name: Copy config files for Home Assistant to {{ hass_config_directory }}/
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ hass_config_directory }}/"
+    mode: u=rw,g=r,o=r
+    backup: true
+  loop:
+    - files/{{ hass_config_directory }}/.storage/core.device_registry
+    - files/{{ hass_config_directory }}/lovelace
+    - files/{{ hass_config_directory }}/known_devices.yaml
+    - files/{{ hass_config_directory }}/automations.yaml
+  notify: Restart hass
 
-# - name: Create secret storage files for Home Assistant to {{ hass_config_directory }}/
-#   ansible.builtin.template:
-#     src: "{{ item.src }}"
-#     dest: "{{ item.dest }}"
-#     mode: u=rw,g=,o=
-#   loop:
-#     - dest: "{{ hass_config_directory }}/.storage/core.config_entries"
-#       src: files/{{ hass_config_directory }}/.storage/core.config_entries.j2
-#     - dest: "{{ hass_config_directory }}/.storage/auth_provider.homeassistant"
-#       src: files/{{ hass_config_directory }}/.storage/auth_provider.homeassistant.j2
-#     - dest: "{{ hass_config_directory }}/.storage/auth"
-#       src: files/{{ hass_config_directory }}/.storage/auth.j2
-#     - dest: "{{ hass_config_directory }}/.storage/auth_module.totp"
-#       src: files/{{ hass_config_directory }}/.storage/auth_module.totp.j2
-#   no_log: true
-#   notify: Restart hass
+- name: Create secret storage files for Home Assistant to {{ hass_config_directory }}/
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: u=rw,g=,o=
+    backup: true
+    force: false
+  loop:
+    - dest: "{{ hass_config_directory }}/.storage/core.config_entries"
+      src: files/{{ hass_config_directory }}/.storage/core.config_entries.j2
+    - dest: "{{ hass_config_directory }}/.storage/auth_provider.homeassistant"
+      src: files/{{ hass_config_directory }}/.storage/auth_provider.homeassistant.j2
+    - dest: "{{ hass_config_directory }}/.storage/auth"
+      src: files/{{ hass_config_directory }}/.storage/auth.j2
+    - dest: "{{ hass_config_directory }}/.storage/auth_module.totp"
+      src: files/{{ hass_config_directory }}/.storage/auth_module.totp.j2
+  no_log: true
+  notify: Restart hass
 
-# - name: Create config files for Home Assistant to {{ hass_config_directory }}
-#   ansible.builtin.template:
-#     src: "{{ item.src }}"
-#     dest: "{{ item.dest }}"
-#     mode: u=rw,g=r,o=r
-#   loop:
-#     - dest: "{{ hass_config_directory }}/configuration.yaml"
-#       src: files/{{ hass_config_directory }}/configuration.yaml.j2
-#   notify: Restart hass
+- name: Create config files for Home Assistant to {{ hass_config_directory }}
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: u=rw,g=r,o=r
+    backup: true
+  loop:
+    - dest: "{{ hass_config_directory }}/configuration.yaml"
+      src: files/{{ hass_config_directory }}/configuration.yaml.j2
+  notify: Restart hass
 
-# - name: Create secret file for Home Assistant to {{ hass_config_directory }}
-#   ansible.builtin.template:
-#     src: "{{ item.src }}"
-#     dest: "{{ item.dest }}"
-#     mode: u=rw,g=,o=
-#   loop:
-#     - dest: "{{ hass_config_directory }}/secrets.yaml"
-#       src: files/{{ hass_config_directory }}/secrets.yaml.j2
-#   no_log: true
-#   notify: Restart hass
+- name: Create secret file for Home Assistant to {{ hass_config_directory }}
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: u=rw,g=,o=
+    backup: true
+  loop:
+    - dest: "{{ hass_config_directory }}/secrets.yaml"
+      src: files/{{ hass_config_directory }}/secrets.yaml.j2
+  no_log: true
+  notify: Restart hass
 
-# - name: Home Assistant container
-#   community.docker.docker_container:
-#     name: home-assistant
-#     image: ghcr.io/home-assistant/home-assistant:2026.4.4@sha256:c1e5f0147f4cb51ccb05bb30b62a1269cc1bd48a6274792d3b38a77ab274dfd2
-#     comparisons:
-#       image: strict
-#       labels: allow_more_present
-#       volumes: allow_more_present
-#     volumes:
-#       - /etc/localtime:/etc/localtime:ro
-#       - /run/dbus:/run/dbus:ro
-#       - "{{ hass_config_directory }}:/config"
-#     network_mode: host
-#     privileged: true
-#     labels:
-#       homepage.group: Containers
-#       homepage.name: Home Assistant
-#       homepage.icon: https://upload.wikimedia.org/wikipedia/en/4/49/Home_Assistant_logo_%282023%29.svg
-#       homepage.href: "{{ hass_url }}"
-#       homepage.description: Open source home automation that puts local control and privacy first.
-#     restart_policy: always
-#     timeout: "{{ docker_container_timeout }}"
-#   notify: Restart hass
+- name: Home Assistant container
+  community.docker.docker_container:
+    name: home-assistant
+    image: ghcr.io/home-assistant/home-assistant:2026.5.2@sha256:f0baa7922ecec7790c40c41baf08ab218b6ab8db5f96dc03b03a0ae33d987c3d
+    comparisons:
+      image: strict
+      labels: allow_more_present
+      volumes: allow_more_present
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - /run/dbus:/run/dbus:ro
+      - "{{ hass_config_directory }}:/config"
+    network_mode: host
+    privileged: true
+    labels:
+      homepage.group: Containers
+      homepage.name: Home Assistant
+      homepage.icon: https://upload.wikimedia.org/wikipedia/en/4/49/Home_Assistant_logo_%282023%29.svg
+      homepage.href: "{{ hass_url }}"
+      homepage.description: Open source home automation that puts local control and privacy first.
+    restart_policy: always
+    timeout: "{{ docker_container_timeout }}"
+  notify: Restart hass
 
 # - name: Wait for HASS to be started
 #   when: not hass_restore_log.stat.exists
@@ -471,47 +414,48 @@
 # Homepage
 #################################################
 
-# - name: Create homepage directory (/var/lib/homepage/config)
-#   ansible.builtin.file:
-#     path: /var/lib/homepage/config
-#     state: directory
-#     recurse: true
+- name: Create homepage directory (/var/lib/homepage/config)
+  ansible.builtin.file:
+    path: /var/lib/homepage/config
+    state: directory
+    recurse: true
 
-# - name: Copy config files for homepage to /var/lib/homepage/config
-#   ansible.builtin.template:
-#     src: "{{ item }}"
-#     dest: "/var/lib/homepage/config/{{ item | basename | regex_replace('\\.j2$', '') }}"
-#     mode: u=rw,g=r,o=r
-#   with_fileglob:
-#     - files/var/lib/homepage/config/*.j2
-#   no_log: true
-#   notify: Restart homepage
+- name: Copy config files for homepage to /var/lib/homepage/config
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: "/var/lib/homepage/config/{{ item | basename | regex_replace('\\.j2$', '') }}"
+    mode: u=rw,g=r,o=r
+    backup: true
+  with_fileglob:
+    - files/var/lib/homepage/config/*.j2
+  no_log: true
+  notify: Restart homepage
 
-# - name: Homepage container
-#   community.docker.docker_container:
-#     name: homepage
-#     image: ghcr.io/gethomepage/homepage:v1.12.3@sha256:cc84f2f5eb3c7734353701ccbaa24ed02dacb0d119114e50e4251e2005f3990a
-#     comparisons:
-#       image: strict
-#       labels: allow_more_present
-#       volumes: allow_more_present
-#     volumes:
-#       - /var/lib/homepage/config:/app/config
-#       - /var/run/docker.sock:/var/run/docker.sock:ro
-#     network_mode: host
-#     privileged: true
-#     env:
-#       LOG_TARGETS: stdout
-#       HOMEPAGE_ALLOWED_HOSTS: "*"
-#     labels:
-#       homepage.group: Containers
-#       homepage.name: Homepage
-#       homepage.icon: https://raw.githubusercontent.com/gethomepage/homepage/47765ee05e633c87fcf8fca8ee1293bf0ef6bb3e/docs/assets/light_squircle%402x.png
-#       homepage.href: https://rpi.xvx.cz/
-#       homepage.description: A modern, fully static, fast, secure fully proxied, highly customizable application dashboard with integrations for over 100 services and translations into multiple languages.
-#     restart_policy: always
-#     timeout: "{{ docker_container_timeout }}"
-#   notify: Restart homepage
+- name: Homepage container
+  community.docker.docker_container:
+    name: homepage
+    image: ghcr.io/gethomepage/homepage:v1.13.1@sha256:d8d784e5090111b6e4c56dfd90e272d2953a2094e87349f647165df0fa6c4401
+    comparisons:
+      image: strict
+      labels: allow_more_present
+      volumes: allow_more_present
+    volumes:
+      - /var/lib/homepage/config:/app/config
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    network_mode: host
+    privileged: true
+    env:
+      LOG_TARGETS: stdout
+      HOMEPAGE_ALLOWED_HOSTS: "*"
+    labels:
+      homepage.group: Containers
+      homepage.name: Homepage
+      homepage.icon: https://raw.githubusercontent.com/gethomepage/homepage/47765ee05e633c87fcf8fca8ee1293bf0ef6bb3e/docs/assets/light_squircle%402x.png
+      homepage.href: https://rpi.xvx.cz/
+      homepage.description: A modern, fully static, fast, secure fully proxied, highly customizable application dashboard with integrations for over 100 services and translations into multiple languages.
+    restart_policy: always
+    timeout: "{{ docker_container_timeout }}"
+  notify: Restart homepage
 
 #################################################
 # Kodi
@@ -541,6 +485,7 @@
     src: files/var/lib/bluetooth/info.j2
     dest: /var/lib/bluetooth/{{ bluetooth_device_address_rpi }}/{{ bluetooth_device_address_headset }}/info
     mode: u=rw,g=,o=
+    backup: true
   no_log: true
 
 - name: Create wireplumber config directory
@@ -566,6 +511,7 @@
     owner: kodi
     group: kodi
     mode: u=rw,g=r,o=r
+    backup: true
 
 - name: Configure WirePlumber default profile
   ansible.builtin.template:
@@ -574,6 +520,7 @@
     owner: kodi
     group: kodi
     mode: u=rw,g=rw,o=r
+    backup: true
 
 - name: Enable and start PipeWire for user kodi # noqa: command-instead-of-module
   become: true
@@ -589,6 +536,7 @@
     src: lib/systemd/system/kodi.service
     dest: /lib/systemd/system/kodi.service
     mode: u=rw,g=r,o=r
+    backup: true
   notify:
     - Restart kodi
 
@@ -611,6 +559,7 @@
     dest: "{{ item.dest }}"
     src: "{{ item.src }}"
     mode: u=rw,g=,o=
+    backup: true
   loop:
     # This file is frequently updated by Kodi
     - dest: /home/kodi/.kodi/userdata/guisettings.xml

--- a/ansible/tasks/system-defaults.yml
+++ b/ansible/tasks/system-defaults.yml
@@ -304,6 +304,7 @@
   ansible.builtin.apt:
     name: firewalld
     state: present
+    install_recommends: false
   register: result
   until: result is succeeded
 

--- a/ansible/tasks/system-defaults.yml
+++ b/ansible/tasks/system-defaults.yml
@@ -12,6 +12,7 @@
     regexp: ".*{{ inventory_hostname }}.*"
     line: "{{ ansible_facts.default_ipv4.address }} {{ inventory_hostname }}"
     mode: u=rw,g=r,o=r
+    backup: true
   when: ansible_facts["default_ipv4"]["address"] is defined
 
 - name: Configure NTP
@@ -22,12 +23,14 @@
     option: NTP
     value: "{{ ntp_server }}"
     mode: u=rw,g=r,o=r
+    backup: true
 
 - name: Copy sshd Ed25519 private key to /etc/ssh/
   ansible.builtin.copy:
     content: "{{ ssh_host_ed25519_key }}\n"
     dest: /etc/ssh/ssh_host_ed25519_key
     mode: u=rw,g=,o=
+    backup: true
   no_log: true
   notify: Restart sshd
 
@@ -36,6 +39,7 @@
     content: "{{ ssh_host_ed25519_key_pub }}\n"
     dest: /etc/ssh/ssh_host_ed25519_key.pub
     mode: u=rw,g=r,o=r
+    backup: true
   no_log: true
   notify: Restart sshd
 
@@ -45,6 +49,7 @@
     regexp: "^#?HostKey /etc/ssh/ssh_host_ed25519_key"
     line: HostKey /etc/ssh/ssh_host_ed25519_key
     mode: u=rw,g=r,o=r
+    backup: true
   notify: Restart sshd
 
 - name: Create /etc/systemd/journald.conf.d directory
@@ -88,10 +93,12 @@
     option: ExecStartPre
     value: /usr/sbin/rfkill unblock bluetooth
     mode: u=rw,g=r,o=r
+    backup: true
 
 - name: Configure .bashrc for root
   ansible.builtin.blockinfile:
     dest: /root/.bashrc
+    backup: true
     block: |
       PS1='\[\033[01;31m\]\h\[\033[01;34m\] \w #\[\033[00m\] '
       source /usr/share/doc/fzf/examples/key-bindings.bash
@@ -182,6 +189,7 @@
     dest: /root/
     remote_src: true
     mode: u=rw,g=r,o=r
+    backup: true
 
 - name: Copy mc configuration to pi home directory
   ansible.builtin.copy:
@@ -191,6 +199,7 @@
     group: pi
     remote_src: true
     mode: u=rw,g=r,o=r
+    backup: true
 
 - name: Put "mc" alias into /etc/profile.d/my-mc.sh
   ansible.builtin.copy:
@@ -199,6 +208,7 @@
       [ -n "${BASH_VERSION}${KSH_VERSION}${ZSH_VERSION}" ] || return 0
       alias mc='. /usr/lib/mc/mc-wrapper.sh --nomouse'
     mode: u=rw,g=r,o=r
+    backup: true
 
 - name: Tweak vim
   ansible.builtin.copy:
@@ -209,11 +219,13 @@
       set ttymouse=
       source /usr/share/doc/fzf/examples/fzf.vim
     mode: u=rw,g=r,o=r
+    backup: true
 
 - name: Tweak logrotate (/etc/logrotate.conf)
   ansible.builtin.blockinfile:
     dest: /etc/logrotate.conf
     insertafter: "^create"
+    backup: true
     block: |
       compress
       compresscmd /usr/bin/xz
@@ -226,6 +238,7 @@
     dest: /etc/msmtprc
     src: files/etc/msmtprc.j2
     mode: u=rw,g=,o=
+    backup: true
   no_log: true
 
 - name: Configure /etc/aliases
@@ -234,12 +247,14 @@
     content: |
       root:           {{ notification_email }}
     mode: u=rw,g=r,o=r
+    backup: true
 
 - name: Configure email notification after reboot
   ansible.builtin.template:
     dest: /etc/rc.local
     src: files/etc/rc.local.j2
     mode: u=rwx,g=rx,o=rx
+    backup: true
 
 - name: Modify Unattended upgrade settings
   ansible.builtin.replace:
@@ -266,6 +281,7 @@
     path: /etc/apt/apt.conf.d/50unattended-upgrades
     marker: "// {mark} ANSIBLE MANAGED BLOCK"
     insertafter: "^Unattended-Upgrade::Origins-Pattern"
+    backup: true
     block: |2
               "origin=*";
 
@@ -279,6 +295,91 @@
     value: "1"
     sysctl_set: true
     reload: true
+
+##############################
+# Firewalld
+##############################
+
+- name: Install firewalld
+  ansible.builtin.apt:
+    name: firewalld
+    state: present
+  register: result
+  until: result is succeeded
+
+- name: Ensure firewalld is started and enabled
+  ansible.builtin.systemd:
+    name: firewalld
+    state: started
+    enabled: true
+
+- name: Allow services
+  ansible.posix.firewalld:
+    service: "{{ item }}"
+    permanent: true
+    immediate: true
+    state: enabled
+  loop: "{{ firewalld_allowed_services }}"
+
+#################################################
+# Docker
+#################################################
+
+- name: Add Docker apt signing keys
+  ansible.builtin.get_url:
+    url: https://download.docker.com/linux/debian/gpg
+    dest: /usr/share/keyrings/docker.gpg
+    mode: u=rw,g=r,o=r
+
+- name: Add Docker repository
+  ansible.builtin.deb822_repository:
+    name: docker
+    uris: https://download.docker.com/linux/debian
+    suites: "{{ ansible_facts.distribution_release }}"
+    components: stable
+    signed_by: /usr/share/keyrings/docker.gpg
+
+- name: Create Docker daemon configuration directory
+  ansible.builtin.file:
+    path: /etc/docker
+    state: directory
+    mode: u=rwx,g=rx,o=rx
+
+- name: Configure Docker daemon
+  ansible.builtin.copy:
+    dest: /etc/docker/daemon.json
+    content: |
+      {{ docker_config | to_nice_json }}
+    mode: u=rw,g=r,o=r
+    backup: true
+  notify: Restart docker
+
+- name: Install docker
+  ansible.builtin.apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+    update_cache: true
+    install_recommends: false
+  register: result
+  until: result is succeeded
+
+- name: Start and enable Docker service
+  ansible.builtin.systemd_service:
+    name: docker
+    state: started
+    enabled: true
+    daemon_reload: true
+
+- name: Add pi and alloy users to the docker group
+  ansible.builtin.user:
+    name: "{{ item }}"
+    groups: docker
+    append: true
+  loop:
+    - pi
+    - alloy
 
 - name: Run all handlers
   ansible.builtin.meta: flush_handlers

--- a/fnox.toml
+++ b/fnox.toml
@@ -11,14 +11,14 @@ ESPHOME_API_ENCRYPTION_KEY = { provider = "ps", value = "/github/ruzickap/ansibl
 ESPHOME_OTA_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/ESPHOME_OTA_PASSWORD", if_missing = "error" }
 ESPHOME_WEB_SERVER_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/ESPHOME_WEB_SERVER_PASSWORD", if_missing = "error" }
 GRAFANA_ADMIN_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/GRAFANA_ADMIN_PASSWORD", if_missing = "error" }
-# HACS_GITHUB_TOKEN = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HACS_GITHUB_TOKEN", if_missing = "error" }
-# HASS_AUTH_PASSWORD_HASH = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HASS_AUTH_PASSWORD_HASH", if_missing = "error" }
-# HASS_AUTH_REFRESH_TOKEN_PROMETHEUS = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HASS_AUTH_REFRESH_TOKEN_PROMETHEUS", if_missing = "error" }
-# HASS_AUTH_REFRESH_TOKEN_PROMETHEUS_JWT_KEY = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HASS_AUTH_REFRESH_TOKEN_PROMETHEUS_JWT_KEY", if_missing = "error" }
-# HASS_AUTH_REFRESH_TOKEN_SYSTEM = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HASS_AUTH_REFRESH_TOKEN_SYSTEM", if_missing = "error" }
-# HASS_AUTH_REFRESH_TOKEN_SYSTEM_JWT_KEY = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HASS_AUTH_REFRESH_TOKEN_SYSTEM_JWT_KEY", if_missing = "error" }
-# HASS_TOTP_SECRET = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HASS_TOTP_SECRET", if_missing = "error" }
-# HASS_USER_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HASS_USER_PASSWORD", if_missing = "error" }
+HACS_GITHUB_TOKEN = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HACS_GITHUB_TOKEN", if_missing = "error" }
+HASS_AUTH_PASSWORD_HASH = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HASS_AUTH_PASSWORD_HASH", if_missing = "error" }
+HASS_AUTH_REFRESH_TOKEN_PROMETHEUS = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HASS_AUTH_REFRESH_TOKEN_PROMETHEUS", if_missing = "error" }
+HASS_AUTH_REFRESH_TOKEN_PROMETHEUS_JWT_KEY = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HASS_AUTH_REFRESH_TOKEN_PROMETHEUS_JWT_KEY", if_missing = "error" }
+HASS_AUTH_REFRESH_TOKEN_SYSTEM = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HASS_AUTH_REFRESH_TOKEN_SYSTEM", if_missing = "error" }
+HASS_AUTH_REFRESH_TOKEN_SYSTEM_JWT_KEY = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HASS_AUTH_REFRESH_TOKEN_SYSTEM_JWT_KEY", if_missing = "error" }
+HASS_TOTP_SECRET = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HASS_TOTP_SECRET", if_missing = "error" }
+HASS_USER_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/HASS_USER_PASSWORD", if_missing = "error" }
 KODI_GUISETTINGS_SERVICES_WEBSERVERPASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/KODI_GUISETTINGS_SERVICES_WEBSERVERPASSWORD", if_missing = "error" }
 MQTT_UZG01_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/MQTT_UZG01_PASSWORD", if_missing = "error" }
 MQTT_ZIGBEE2MQTT_PASSWORD = { provider = "ps", value = "/github/ruzickap/ansible-raspberry-pi-os/ansible/MQTT_ZIGBEE2MQTT_PASSWORD", if_missing = "error" }

--- a/mise.toml
+++ b/mise.toml
@@ -13,7 +13,7 @@ description = "Run Ansible playbook"
 dir = "ansible"
 shell = "bash -c"
 run = """
-set -o pipefail
+set -euo pipefail
 ansible-galaxy install -r requirements.yml
 ansible-playbook --diff -i inventory/hosts main.yml 2>&1 | tee /tmp/ansible-raspberry-pi-os.log
 """

--- a/mise.toml
+++ b/mise.toml
@@ -13,6 +13,7 @@ description = "Run Ansible playbook"
 dir = "ansible"
 shell = "bash -c"
 run = """
+set -o pipefail
 ansible-galaxy install -r requirements.yml
 ansible-playbook --diff -i inventory/hosts main.yml 2>&1 | tee /tmp/ansible-raspberry-pi-os.log
 """

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
-# ansible = "latest"
-fnox = "1.23.1"
+ansible = "13.6.0"
+fnox = "1.24.0"
 
 [plugins]
 fnox-env = "https://github.com/jdx/mise-env-fnox"
@@ -13,11 +13,6 @@ description = "Run Ansible playbook"
 dir = "ansible"
 shell = "bash -c"
 run = """
-set -euxo pipefail
 ansible-galaxy install -r requirements.yml
-if [ ! -f /tmp/ansible-raspberry-pi-os.log ]; then
-  ansible-playbook --diff -i inventory/hosts main.yml 2>&1 | tee /tmp/ansible-raspberry-pi-os.log
-else
-  ansible-playbook --diff -i inventory/hosts main.yml
-fi
+ansible-playbook --diff -i inventory/hosts main.yml 2>&1 | tee /tmp/ansible-raspberry-pi-os.log
 """


### PR DESCRIPTION
## Summary

Enable Home Assistant, Homepage dashboard containers and replace the
firewall implementation with firewalld.

## Changes

### Containers Enabled
- **Home Assistant** (2026.5.2) - previously commented out, now fully
  configured with storage, auth, and config files
- **Homepage** (v1.13.1) - dashboard container with service monitoring

### Firewall Migration
- Remove `geerlingguy.firewall` role and iptables-based rules
- Add `firewalld` with service-based allow rules (ssh, mdns, mqtt)

### Infrastructure Reorganization
- Move Docker setup (repo, daemon config, service) from `apps.yml` to
  `system-defaults.yml`
- Remove Docker section duplication

### Monitoring Updates
- Add Grafana Cloud metrics forwarding to all Alloy scrape targets
- Add Home Assistant Prometheus scrape target
- Add laptop (peru-laptop) node_exporter scrape target
- Rename ESPHome target to msr-2 (device-specific)

### Version Updates
- Zigbee2MQTT: 2.10.0 -> 2.10.1 (moved to ghcr.io)
- ESPHome: 2026.4.2 -> 2026.4.5
- Alloy: 1.16.0 -> 1.16.1
- fnox: 1.23.1 -> 1.24.0
- ansible: enabled at 13.6.0
- Zigbee2MQTT config: version 4 -> 5

### Other Changes
- Add `backup: true` to file/template tasks for rollback safety
- Remove cloud-init from disabled boot services
- Inline mosquitto password_file template (delete standalone file)
- Change Zigbee2MQTT port 8082 -> 8090
- Uncomment HASS secrets in fnox.toml and group_vars
- Disable Prometheus backup/restore tasks (commented out)
- Fix HDMI audio platform path in wireplumber config
- Simplify mise.toml run task
- Add `prometheus_scrape_configs: []` (Alloy handles scraping)