### PR TITLE
fix: disable Bluetooth and correct Homepage icon

### DIFF
--- a/ansible/files/var/lib/hass_config/.storage/core.config_entries.j2
+++ b/ansible/files/var/lib/hass_config/.storage/core.config_entries.j2
@@ -25,7 +25,7 @@
         "created_at": "2024-10-20T12:26:32.488664+00:00",
         "data": {},
         "discovery_keys": {},
-        "disabled_by": null,
+        "disabled_by": "user",
         "domain": "bluetooth",
         "entry_id": "01JAMY9EN8PNNY50XQQH01WPK8",
         "minor_version": 1,

--- a/ansible/files/var/lib/homepage/config/widgets.yaml.j2
+++ b/ansible/files/var/lib/homepage/config/widgets.yaml.j2
@@ -18,4 +18,4 @@
     text: {{ inventory_hostname }} | {{ ansible_facts["default_ipv4"]["address"] }}
 
 - logo:
-    icon: raspberrypi.svg
+    icon: raspberry-pi.svg


### PR DESCRIPTION
## Summary

- disable the Home Assistant Bluetooth config entry by default
- correct the Raspberry Pi icon name used by Homepage

## Validation

- pre-commit hooks passed during commit
- `python3 -m json.tool` validated the Home Assistant JSON template
- `git diff --check` passed